### PR TITLE
Registered MsgServer Route

### DIFF
--- a/x/ssi/module.go
+++ b/x/ssi/module.go
@@ -142,6 +142,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 }
 
 // RegisterInvariants registers the capability module's invariants.


### PR DESCRIPTION
- Added Message Server Router in `module.go` to support `ssi` module related transactions using `authz` and `feegrant` module