### PR TITLE
Marshal Method change for `Schema` Type

### DIFF
--- a/x/ssi/types/message_schema.go
+++ b/x/ssi/types/message_schema.go
@@ -39,8 +39,7 @@ func (msg *MsgCreateSchema) GetSignBytes() []byte {
 }
 
 func (msg *Schema) GetSignBytes() []byte {
-	bz := ModuleCdc.MustMarshalJSON(msg)
-	return sdk.MustSortJSON(bz)
+	return ModuleCdc.MustMarshal(msg)
 }
 
 func (msg *MsgCreateSchema) ValidateBasic() error {


### PR DESCRIPTION
The marshalling method of Schema has been changed from `MustMarshalJSON` to `MustMarshal`, to align with hs-ssi-sdk's encoding 