### PR TITLE
Automatic Update for Expired Credential Statuses

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -26,6 +26,7 @@ import (
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
+	"github.com/cosmos/cosmos-sdk/x/authz"
 	authzkeeper "github.com/cosmos/cosmos-sdk/x/authz/keeper"
 	authzmodule "github.com/cosmos/cosmos-sdk/x/authz/module"
 	"github.com/cosmos/cosmos-sdk/x/bank"
@@ -415,7 +416,7 @@ func New(
 	app.mm.SetOrderBeginBlockers(
 		upgradetypes.ModuleName, capabilitytypes.ModuleName, minttypes.ModuleName, distrtypes.ModuleName, slashingtypes.ModuleName,
 		evidencetypes.ModuleName, stakingtypes.ModuleName, ibchost.ModuleName,
-		feegrant.ModuleName,
+		feegrant.ModuleName, authz.ModuleName, ssimoduletypes.ModuleName,
 	)
 
 	app.mm.SetOrderEndBlockers(crisistypes.ModuleName, govtypes.ModuleName, stakingtypes.ModuleName)

--- a/x/ssi/abci.go
+++ b/x/ssi/abci.go
@@ -1,0 +1,15 @@
+package ssi
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/hypersign-protocol/hid-node/x/ssi/keeper"
+)
+
+// BeginBlocker is called at the beginning of every block
+func BeginBlocker(ctx sdk.Context, k keeper.Keeper) {
+	// Set all the credential status that have passed their expiration date
+	// to Expired
+	if err := k.SetCredentialStatusToExpired(ctx); err != nil {
+		panic(err)
+	}
+}

--- a/x/ssi/keeper/msg_server_credential.go
+++ b/x/ssi/keeper/msg_server_credential.go
@@ -227,7 +227,6 @@ func (k msgServer) updateCredentialStatus(ctx sdk.Context, newCredStatus *types.
 				fmt.Sprintf("credential is already %s", newClaimStatus))
 		}
 
-	// TODO: Status change to Expired should happend automatically within hid-node
 	case "Revoked", "Expired":
 		if newClaimStatus == oldClaimStatus {
 			return nil, sdkerrors.Wrapf(

--- a/x/ssi/module.go
+++ b/x/ssi/module.go
@@ -170,7 +170,9 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
-func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
+func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
+	BeginBlocker(ctx, am.keeper)
+}
 
 // EndBlock executes all ABCI EndBlock logic respective to the capability module. It
 // returns no validator updates.


### PR DESCRIPTION
Closes https://github.com/hypersign-protocol/hid-node/issues/158

Once the current block time is greater than expiration date:

- Credential Status is changed to `Expired`
- Status Reason is updated to `Credential Expired`
- `updated` is set to current block time