### PR TITLE
Include `allow_colon_final_segments` param in grpc-gateway proto generation command

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -22,7 +22,7 @@ Mgoogle/protobuf/any.proto=github.com/cosmos/cosmos-sdk/codec/types:. \
   -I "third_party/proto" \
   -I "$cosmos_sdk_dir/third_party/proto" \
   -I "$cosmos_sdk_dir/proto" \
-  --grpc-gateway_out=logtostderr=true:. \
+  --grpc-gateway_out=logtostderr=true,allow_colon_final_segments=true:. \
   $(find "${dir}" -maxdepth 1 -name '*.proto')
 done
 

--- a/x/ssi/types/query.pb.gw.go
+++ b/x/ssi/types/query.pb.gw.go
@@ -612,17 +612,17 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 }
 
 var (
-	pattern_Query_QuerySchema_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"hypersign-protocol", "hidnode", "ssi", "schema", "schemaId"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_QuerySchema_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"hypersign-protocol", "hidnode", "ssi", "schema", "schemaId"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_QuerySchemas_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"hypersign-protocol", "hidnode", "ssi", "schema"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_QuerySchemas_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"hypersign-protocol", "hidnode", "ssi", "schema"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_QueryDidDocument_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"hypersign-protocol", "hidnode", "ssi", "did", "didId"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_QueryDidDocument_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"hypersign-protocol", "hidnode", "ssi", "did", "didId"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_QueryDidDocuments_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"hypersign-protocol", "hidnode", "ssi", "did"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_QueryDidDocuments_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"hypersign-protocol", "hidnode", "ssi", "did"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_QueryCredential_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"hypersign-protocol", "hidnode", "ssi", "credential", "credId"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_QueryCredential_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"hypersign-protocol", "hidnode", "ssi", "credential", "credId"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_QueryCredentials_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"hypersign-protocol", "hidnode", "ssi", "credential"}, "", runtime.AssumeColonVerbOpt(true)))
+	pattern_Query_QueryCredentials_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"hypersign-protocol", "hidnode", "ssi", "credential"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (


### PR DESCRIPTION
Closes: https://github.com/hypersign-protocol/hid-node/issues/4

Adding `allow_colon_final_segments=true` param in grpc-gateway proto generation cmd, will enable gRPC server to include the last segment of document ID.