### PR TITLE
Fix: `method-specific-id` length check removed

### DIFF
--- a/tests/e2e/ssi_tests/utils.py
+++ b/tests/e2e/ssi_tests/utils.py
@@ -46,8 +46,6 @@ def generate_key_pair(algo="ed25519"):
         raise Exception(algo + " is not a supported signing algorithm")
     result_str = run_command(cmd)
     kp = json.loads(result_str)
-    if len(kp["pub_key_multibase"]) != 45:
-        return generate_key_pair()
     return kp
 
 def generate_document_id(doc_type: str, kp: dict = None):

--- a/x/ssi/keeper/document_verification/common_checks.go
+++ b/x/ssi/keeper/document_verification/common_checks.go
@@ -89,7 +89,7 @@ func IsValidID(Id string, namespace string, docType string) error {
 
 	// Check if method-specific-id follows multibase format
 	_, _, err := multibase.Decode(docElements[docMethodSpecificId])
-	if err != nil || len(docElements[docMethodSpecificId]) != 45 {
+	if err != nil {
 		return sdkerrors.Wrap(types.ErrInvalidMethodSpecificId, docElements[docMethodSpecificId])
 	}
 


### PR DESCRIPTION
Closes: https://github.com/hypersign-protocol/hid-node/issues/309