### PR TITLE
Docker Setup Script fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ COMMIT := $(shell git rev-parse --short HEAD)
 
 BUILD_DIR ?= $(CURDIR)/build
 HIDNODE_CMD_DIR := $(CURDIR)/cmd/hid-noded
+E2E_SSI_TESTS_DIR := $(CURDIR)/tests/e2e/ssi_tests
 
 GOBIN = $(shell go env GOPATH)/bin
 GOOS = $(shell go env GOOS)
@@ -55,3 +56,20 @@ proto-gen:
 swagger-docs-gen:
 	@echo "Generating swagger docs"
 	./scripts/protoc-swagger-gen.sh
+
+
+###############################################################################
+###                                  Docker                                 ###
+###############################################################################
+DOCKER_IMAGE_NAME := hid-node-image
+
+docker-all: docker-build docker-run
+
+docker-build:
+	docker build -t $(DOCKER_IMAGE_NAME) .
+
+docker-run:
+	docker run --rm -d \
+	-p 26657:26657 -p 1317:1317 -p 26656:26656 -p 9090:9090 \
+	--name hid-node-container \
+	$(DOCKER_IMAGE_NAME) start

--- a/README.md
+++ b/README.md
@@ -56,16 +56,19 @@ hid-noded start --home ~/.hid-node
 
 ### Docker
 
-To run a single node `hid-node` docker container, run the following:
+To run a single node `hid-node` docker container, follow the below steps:
 
 1. Pull the image:
    ```sh
    docker pull ghcr.io/hypersign-protocol/hid-node:latest
    ```
 
-2. Open a separate terminal window. Run the node:
+2. Run the following:
    ```sh
-   docker run -it ghcr.io/hypersign-protocol/hid-node start
+   docker run --rm -d \
+	-p 26657:26657 -p 1317:1317 -p 26656:26656 -p 9090:9090 \
+	--name hid-node-container \
+	ghcr.io/hypersign-protocol/hid-node start
    ```
 
 ## Documentation

--- a/scripts/docker-node/setup.sh
+++ b/scripts/docker-node/setup.sh
@@ -38,7 +38,7 @@ cat /root/.hid-node/config/genesis.json | jq '.app_state["crisis"]["constant_fee
 
 # update gov genesis
 cat /root/.hid-node/config/genesis.json | jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="uhid"' > /root/.hid-node/config/tmp_genesis.json && mv /root/.hid-node/config/tmp_genesis.json /root/.hid-node/config/genesis.json
-cat /root/.hid-node/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="50s"' > /root/.hid-node/config/tmp_genesis.json && mv /root/.hid-node/config/tmp_genesis.json /root/.hid-node/config/genesis.json
+cat /root/.hid-node/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="500s"' > /root/.hid-node/config/tmp_genesis.json && mv /root/.hid-node/config/tmp_genesis.json /root/.hid-node/config/genesis.json
 
 # update ssi genesis
 cat /root/.hid-node/config/genesis.json | jq '.app_state["ssi"]["chain_namespace"]="devnet"' > /root/.hid-node/config/tmp_genesis.json && mv /root/.hid-node/config/tmp_genesis.json /root/.hid-node/config/genesis.json
@@ -47,8 +47,8 @@ cat /root/.hid-node/config/genesis.json | jq '.app_state["ssi"]["chain_namespace
 cat /root/.hid-node/config/genesis.json | jq '.app_state["mint"]["params"]["mint_denom"]="uhid"' > /root/.hid-node/config/tmp_genesis.json && mv /root/.hid-node/config/tmp_genesis.json /root/.hid-node/config/genesis.json
 
 # create validator node with tokens
-hid-noded add-genesis-account $(hid-noded keys show node1 -a --keyring-backend=test --home=/root/.hid-node) 50000000000000000uhid --home=/root/.hid-node
-hid-noded gentx node1 50000000000000000uhid --keyring-backend=test --home=/root/.hid-node --chain-id=hidnode
+hid-noded add-genesis-account $(hid-noded keys show node1 -a --keyring-backend=test --home=/root/.hid-node) 110000000000uhid --home=/root/.hid-node
+hid-noded gentx node1 100000000000uhid --keyring-backend=test --home=/root/.hid-node --chain-id=hidnode
 hid-noded collect-gentxs --home=/root/.hid-node
 
 # change app.toml values
@@ -57,6 +57,7 @@ sed -i -E '107s/swagger = false/swagger = true/' /root/.hid-node/config/app.toml
 
 
 # change config.toml values
+sed -i -E 's|tcp://127.0.0.1:26657|tcp://0.0.0.0:26657|g' /root/.hid-node/config/config.toml
 sed -i -E 's|allow_duplicate_ip = false|allow_duplicate_ip = true|g' /root/.hid-node/config/config.toml
 sed -i -E 's|addr_book_strict = true|addr_book_strict = false|g' /root/.hid-node/config/config.toml
 sed -i -E 's|cors_allowed_origins = \[\]|cors_allowed_origins = \[\"\*\"\]|g' /root/.hid-node/config/config.toml


### PR DESCRIPTION
This PR brings about change in the setup script for Docker node. The RPC IP was left as `localhost`, because of which external interaction with RPC was not happening. Instructions have been added to replace the `localhost` IP with `0.0.0.0`