### PR TITLE
Bugfix: fixed `DocumentProofTypeCheck()` function

### DIFF
--- a/tests/e2e/ssi_tests/run.py
+++ b/tests/e2e/ssi_tests/run.py
@@ -6,6 +6,7 @@ def run_all_tests():
     
     simple_ssi_flow()
     controller_creates_schema_cred_status()
+    controllers_create_schema_cred_status()
     invalid_case_controller_creates_schema_cred_status()
     non_controller_did_trying_to_update_diddoc()
     controller_did_trying_to_update_diddoc()

--- a/x/ssi/tests/query_credential_test.go
+++ b/x/ssi/tests/query_credential_test.go
@@ -19,7 +19,7 @@ func TestQueryCredential(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateEd25519KeyPair()
-	didRpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	didRpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	didId := didRpcElements.DidDocument.GetId()
 	t.Logf("Registering DID with DID Id: %s", didId)
 
@@ -92,7 +92,7 @@ func TestQueryCredentials(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateEd25519KeyPair()
-	didRpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	didRpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	didId := didRpcElements.DidDocument.GetId()
 	t.Logf("Registering DID with DID Id: %s", didId)
 

--- a/x/ssi/tests/query_did_test.go
+++ b/x/ssi/tests/query_did_test.go
@@ -18,7 +18,7 @@ func TestQueryDidDocument(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateEd25519KeyPair()
-	rpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	didId := rpcElements.DidDocument.GetId()
 	t.Logf("Registering DID with DID Id: %s", didId)
 
@@ -64,7 +64,7 @@ func TestQueryDidDocuments(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateEd25519KeyPair()
-	rpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	didId := rpcElements.DidDocument.GetId()
 	t.Logf("Registering DID with DID Id: %s", didId)
 

--- a/x/ssi/tests/query_schema_test.go
+++ b/x/ssi/tests/query_schema_test.go
@@ -18,7 +18,7 @@ func TestQuerySchema(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateEd25519KeyPair()
-	rpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	didId := rpcElements.DidDocument.GetId()
 	t.Logf("Registering DID with DID Id: %s", didId)
 
@@ -88,7 +88,7 @@ func TestQuerySchemas(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateEd25519KeyPair()
-	rpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	didId := rpcElements.DidDocument.GetId()
 	t.Logf("Registering DID with DID Id: %s", didId)
 

--- a/x/ssi/tests/tx_create_did_test.go
+++ b/x/ssi/tests/tx_create_did_test.go
@@ -19,7 +19,7 @@ func TestCreateDIDUsingEd25519KeyPair(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateEd25519KeyPair()
-	rpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements := GenerateDidDocumentRPCElements(keyPair1,[]DidSigningElements{})
 	t.Logf("Registering DID with DID Id: %s", rpcElements.DidDocument.GetId())
 
 	msgCreateDID := &types.MsgCreateDID{
@@ -49,7 +49,7 @@ func TestCreateDIDUsingSecp256k1KeyPair(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateSecp256k1KeyPair()
-	rpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 
 	msgCreateDID := &types.MsgCreateDID{
 		DidDocString: rpcElements.DidDocument,
@@ -75,7 +75,7 @@ func TestInvalidServiceType(t *testing.T) {
 	goCtx := sdk.WrapSDKContext(ctx)
 
 	keyPair1 := GenerateEd25519KeyPair()
-	rpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	// Set Namespace
 	k.SetChainNamespace(&ctx, "devnet")
 
@@ -134,7 +134,7 @@ func TestCheckValidMethodSpecificId(t *testing.T) {
 
 	t.Log("Registering DID Document with Valid Method Specific ID")
 
-	rpcElements = GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements = GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	msgCreateDID = &types.MsgCreateDID{
 		DidDocString: rpcElements.DidDocument,
 		Signatures:   rpcElements.Signatures,
@@ -151,7 +151,7 @@ func TestCheckValidMethodSpecificId(t *testing.T) {
 
 	t.Logf("Registering DID Document with Invalid Method Specific ID - %s", keyPair2.optionalID)
 
-	rpcElements = GenerateDidDocumentRPCElements(keyPair2)
+	rpcElements = GenerateDidDocumentRPCElements(keyPair2, []DidSigningElements{})
 	msgCreateDID = &types.MsgCreateDID{
 		DidDocString: rpcElements.DidDocument,
 		Signatures:   rpcElements.Signatures,
@@ -169,7 +169,7 @@ func TestCheckValidMethodSpecificId(t *testing.T) {
 
 	t.Logf("Registering DID Document with Invalid Method Specific ID - %s", keyPair3.optionalID)
 
-	rpcElements = GenerateDidDocumentRPCElements(keyPair3)
+	rpcElements = GenerateDidDocumentRPCElements(keyPair3, []DidSigningElements{})
 	msgCreateDID = &types.MsgCreateDID{
 		DidDocString: rpcElements.DidDocument,
 		Signatures:   rpcElements.Signatures,

--- a/x/ssi/tests/tx_create_schema_test.go
+++ b/x/ssi/tests/tx_create_schema_test.go
@@ -17,7 +17,7 @@ func TestCreateSchema(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateSecp256k1KeyPair()
-	rpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	t.Logf("Registering DID with DID Id: %s", rpcElements.DidDocument.GetId())
 
 	msgCreateDID := &types.MsgCreateDID{
@@ -39,6 +39,104 @@ func TestCreateSchema(t *testing.T) {
 		keyPair1,
 		rpcElements.DidDocument.Id,
 		rpcElements.DidDocument.AssertionMethod[0],
+	)
+
+	msgCreateSchema := &types.MsgCreateSchema{
+		SchemaDoc:   schemaRpcElements.SchemaDocument,
+		SchemaProof: schemaRpcElements.SchemaProof,
+		Creator:     schemaRpcElements.Creator,
+	}
+
+	_, errCreateSchema := msgServer.CreateSchema(goCtx, msgCreateSchema)
+	if errCreateSchema != nil {
+		t.Error("Schema Registeration Failed")
+		t.Error(errCreateSchema)
+		t.FailNow()
+	}
+	t.Log("Schema Registered Successfully")
+
+	t.Log("Create Schema Tx Test Completed")
+}
+
+func TestCreateSchemaWithMultiControllerDid(t *testing.T) {
+	t.Log("Running test for Valid Create Schmea Tx")
+	k, ctx := TestKeeper(t)
+	msgServer := keeper.NewMsgServerImpl(*k)
+	goCtx := sdk.WrapSDKContext(ctx)
+
+	k.SetChainNamespace(&ctx, "devnet")
+
+	keyPair1 := GenerateSecp256k1KeyPair()
+	rpcElements1 := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
+	t.Logf("Registering Employee 1 with DID Id: %s", rpcElements1.DidDocument.GetId())
+
+	msgCreateDID := &types.MsgCreateDID{
+		DidDocString: rpcElements1.DidDocument,
+		Signatures:   rpcElements1.Signatures,
+		Creator:      rpcElements1.Creator,
+	}
+
+	_, err := msgServer.CreateDID(goCtx, msgCreateDID)
+	if err != nil {
+		t.Error("DID Registeration Failed")
+		t.Error(err)
+		t.FailNow()
+	}
+	t.Log("Employee 1 DID Registered Successfully")
+
+	keyPair2 := GenerateSecp256k1KeyPair()
+	rpcElements2 := GenerateDidDocumentRPCElements(keyPair2, []DidSigningElements{})
+	t.Logf("Registering Employee 2 with DID Id: %s", rpcElements2.DidDocument.GetId())
+
+	msgCreateDID = &types.MsgCreateDID{
+		DidDocString: rpcElements2.DidDocument,
+		Signatures:   rpcElements2.Signatures,
+		Creator:      rpcElements2.Creator,
+	}
+
+	_, err = msgServer.CreateDID(goCtx, msgCreateDID)
+	if err != nil {
+		t.Error("DID Registeration Failed")
+		t.Error(err)
+		t.FailNow()
+	}
+	t.Log("Employee 2 DID Registered Successfully")
+
+	keyPairOrg := GenerateSecp256k1KeyPair()
+	singingElements := []DidSigningElements{
+		DidSigningElements{
+			keyPair: keyPair1,
+			vmId: rpcElements1.DidDocument.VerificationMethod[0].Id,
+		},
+		DidSigningElements{
+			keyPair: keyPair2,
+			vmId: rpcElements2.DidDocument.VerificationMethod[0].Id,
+		},
+	}
+	rpcElementsOrg := GenerateDidDocumentRPCElements(keyPairOrg, singingElements)
+	t.Logf("Registering Org with DID Id: %s", rpcElementsOrg.DidDocument.GetId())
+
+	msgCreateDID = &types.MsgCreateDID{
+		DidDocString: rpcElementsOrg.DidDocument,
+		Signatures:   rpcElementsOrg.Signatures,
+		Creator:      rpcElementsOrg.Creator,
+	}
+
+	_, err = msgServer.CreateDID(goCtx, msgCreateDID)
+	if err != nil {
+		t.Error("DID Registeration Failed")
+		t.Error(err)
+		t.FailNow()
+	}
+	t.Log("Org DID Registered Successfully")
+
+
+
+	t.Log("Registering Schema")
+	schemaRpcElements := GenerateSchemaDocumentRPCElements(
+		keyPair1,
+		rpcElementsOrg.DidDocument.Id,
+		rpcElements1.DidDocument.AssertionMethod[0],
 	)
 
 	msgCreateSchema := &types.MsgCreateSchema{

--- a/x/ssi/tests/tx_deactivate_did_test.go
+++ b/x/ssi/tests/tx_deactivate_did_test.go
@@ -17,7 +17,7 @@ func TestDeactivateDID(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateEd25519KeyPair()
-	rpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	t.Logf("Registering DID with DID Id: %s", rpcElements.DidDocument.GetId())
 
 	msgCreateDID := &types.MsgCreateDID{

--- a/x/ssi/tests/tx_register_credential_status_test.go
+++ b/x/ssi/tests/tx_register_credential_status_test.go
@@ -18,7 +18,7 @@ func TestRegisterCredentialStatus(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateSecp256k1KeyPair()
-	didRpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	didRpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	t.Logf("Registering DID with DID Id: %s", didRpcElements.DidDocument.GetId())
 
 	msgCreateDID := &types.MsgCreateDID{
@@ -62,6 +62,105 @@ func TestRegisterCredentialStatus(t *testing.T) {
 	t.Log("Valid Register Cred Tx Test Completed")
 }
 
+func TestCreateCredentialStatusWithMultiControllerDid(t *testing.T) {
+	t.Log("Running test for Valid Create Schmea Tx")
+	k, ctx := TestKeeper(t)
+	msgServer := keeper.NewMsgServerImpl(*k)
+	goCtx := sdk.WrapSDKContext(ctx)
+
+	k.SetChainNamespace(&ctx, "devnet")
+
+	keyPair1 := GenerateSecp256k1KeyPair()
+	rpcElements1 := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
+	t.Logf("Registering Employee 1 with DID Id: %s", rpcElements1.DidDocument.GetId())
+
+	msgCreateDID := &types.MsgCreateDID{
+		DidDocString: rpcElements1.DidDocument,
+		Signatures:   rpcElements1.Signatures,
+		Creator:      rpcElements1.Creator,
+	}
+
+	_, err := msgServer.CreateDID(goCtx, msgCreateDID)
+	if err != nil {
+		t.Error("DID Registeration Failed")
+		t.Error(err)
+		t.FailNow()
+	}
+	t.Log("Employee 1 DID Registered Successfully")
+
+	keyPair2 := GenerateSecp256k1KeyPair()
+	rpcElements2 := GenerateDidDocumentRPCElements(keyPair2, []DidSigningElements{})
+	t.Logf("Registering Employee 2 with DID Id: %s", rpcElements2.DidDocument.GetId())
+
+	msgCreateDID = &types.MsgCreateDID{
+		DidDocString: rpcElements2.DidDocument,
+		Signatures:   rpcElements2.Signatures,
+		Creator:      rpcElements2.Creator,
+	}
+
+	_, err = msgServer.CreateDID(goCtx, msgCreateDID)
+	if err != nil {
+		t.Error("DID Registeration Failed")
+		t.Error(err)
+		t.FailNow()
+	}
+	t.Log("Employee 2 DID Registered Successfully")
+
+	keyPairOrg := GenerateSecp256k1KeyPair()
+	singingElements := []DidSigningElements{
+		DidSigningElements{
+			keyPair: keyPair1,
+			vmId: rpcElements1.DidDocument.VerificationMethod[0].Id,
+		},
+		DidSigningElements{
+			keyPair: keyPair2,
+			vmId: rpcElements2.DidDocument.VerificationMethod[0].Id,
+		},
+	}
+	rpcElementsOrg := GenerateDidDocumentRPCElements(keyPairOrg, singingElements)
+	t.Logf("Registering Org with DID Id: %s", rpcElementsOrg.DidDocument.GetId())
+
+	msgCreateDID = &types.MsgCreateDID{
+		DidDocString: rpcElementsOrg.DidDocument,
+		Signatures:   rpcElementsOrg.Signatures,
+		Creator:      rpcElementsOrg.Creator,
+	}
+
+	_, err = msgServer.CreateDID(goCtx, msgCreateDID)
+	if err != nil {
+		t.Error("DID Registeration Failed")
+		t.Error(err)
+		t.FailNow()
+	}
+	t.Log("Org DID Registered Successfully")
+
+	t.Log("Registering Schema")
+	credRpcElements := GenerateCredStatusRPCElements(
+		keyPair2,
+		rpcElementsOrg.DidDocument.Id,
+		rpcElements2.DidDocument.VerificationMethod[0],
+	)
+
+	msgRegisterCredentialStatus := &types.MsgRegisterCredentialStatus{
+		CredentialStatus: credRpcElements.Status,
+		Proof:            credRpcElements.Proof,
+		Creator:          Creator,
+	}
+	t.Logf("Registering Credential Status with Id: %s", credRpcElements.Status.GetClaim().GetId())
+
+	t.Logf("Block Time: %s", ctx.BlockTime().Format(time.RFC3339))
+
+	_, errCredStatus := msgServer.RegisterCredentialStatus(goCtx, msgRegisterCredentialStatus)
+	if errCredStatus != nil {
+		t.Error("Credential Status Registeration Failed")
+		t.Error(errCredStatus)
+		t.FailNow()
+	}
+	t.Log("Credential Status Registeration Successful")
+
+	t.Log("Valid Register Cred Tx Test Completed")
+}
+
 func TestUpdateCredentialStatus(t *testing.T) {
 	t.Log("Running test for updating status of registered credential status")
 	k, ctx := TestKeeper(t)
@@ -71,7 +170,7 @@ func TestUpdateCredentialStatus(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateEd25519KeyPair()
-	didRpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	didRpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	t.Logf("Registering DID with DID Id: %s", didRpcElements.DidDocument.GetId())
 
 	msgCreateDID := &types.MsgCreateDID{

--- a/x/ssi/tests/tx_update_did_test.go
+++ b/x/ssi/tests/tx_update_did_test.go
@@ -18,7 +18,7 @@ func TestUpdateDID(t *testing.T) {
 	k.SetChainNamespace(&ctx, "devnet")
 
 	keyPair1 := GenerateEd25519KeyPair()
-	rpcElements := GenerateDidDocumentRPCElements(keyPair1)
+	rpcElements := GenerateDidDocumentRPCElements(keyPair1, []DidSigningElements{})
 	t.Logf("Registering DID with DID Id: %s", rpcElements.DidDocument.GetId())
 
 	msgCreateDID := &types.MsgCreateDID{

--- a/x/ssi/tests/utils.go
+++ b/x/ssi/tests/utils.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"crypto/ed25519"
+	"strings"
 )
 
 func SignGeneric(keyPair GenericKeyPair, data []byte) []byte {
@@ -29,4 +30,9 @@ func GetPublicKeyAndOptionalID(keyPair GenericKeyPair) (string, string) {
 	default:
 		panic("Unsupported Key Pair Type")
 	}
+}
+
+func stripDidFromVerificationMethod(vmId string) string {
+	segments := strings.Split(vmId, "#")
+	return segments[0]
 }

--- a/x/ssi/verification/signature_verification.go
+++ b/x/ssi/verification/signature_verification.go
@@ -62,19 +62,20 @@ func VerifyDidSignature(ctx *sdk.Context, didDocBytes []byte, signers []types.Si
 
 func DocumentProofTypeCheck(inputProofType string, signers []types.Signer, vmId string) error {
 	var vmType string
-
+	var expectedProofType string
+	
 	for i := 0; i < len(signers); i++ {
-		var err error
-		_, vmType, err = utils.FindPublicKeyAndVerificationMethodType(
-			signers[i],
-			vmId,
-		)
-		if err != nil {
-			return err
+		if signers[i].VerificationMethod[0].Id == vmId {
+			vmType = signers[i].VerificationMethod[0].Type
+			break
 		}
 	}
 
-	var expectedProofType string = VerificationKeySignatureMap[vmType]
+	if vmType == "" {
+		return types.ErrVerificationMethodNotFound.Wrap(vmId)
+	}
+
+	expectedProofType = VerificationKeySignatureMap[vmType]
 	if inputProofType != expectedProofType {
 		return fmt.Errorf(
 			"expected document proof type for verification method type %s to be '%s', recieved '%s'",


### PR DESCRIPTION
Reference issue: https://github.com/hypersign-protocol/hid-node/issues/324

Earlier, the `DocumentProofTypeCheck()` function was iterating through all the Signers corresponding to Document's Author, and it was asserted against the `verificationMethodId` from the Document's `Proof`. The problem was when the assertion failed, it threw an error that stated that required verification method id was not found, even though it was present in the Singer.

The function is refactored to iterate over all the signers and pick the singer's VM Id that matches with Verification Method ID present in Document's proof without breaking on non-matching cases. 