### PR TITLE
fix: added `WithViper()` method in `initClientCtx` to get the TmNode client

### DIFF
--- a/cmd/hid-noded/cmd/root.go
+++ b/cmd/hid-noded/cmd/root.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/config"
 	"github.com/cosmos/cosmos-sdk/client/debug"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
@@ -50,12 +51,23 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		WithInput(os.Stdin).
 		WithAccountRetriever(types.AccountRetriever{}).
 		WithBroadcastMode(flags.BroadcastBlock).
-		WithHomeDir(hidnode.DefaultNodeHome)
+		WithHomeDir(hidnode.DefaultNodeHome).
+		WithViper("")
 
 	rootCmd := &cobra.Command{
 		Use:   "hid-noded",
 		Short: "Hypersign Identity Network (hid-noded) CLI",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			initClientCtx, err = config.ReadFromClientConfig(initClientCtx)
+			if err != nil {
+				return err
+			}
+
 			if err := client.SetCmdClientContextHandler(initClientCtx, cmd); err != nil {
 				return err
 			}


### PR DESCRIPTION
There were some changes made in Cosmos SDK `v0.45.10` which led to variable shadowing of Tendermint Node instance. This resulted in the following error for any API call made:

```json
{
  "code": 2,
  "message": "no RPC client is defined in offline mode",
  "details": []
}
```

The variable showing issue will be fixed in Cosmos SDK `v0.45.12`, however one of the ways it was fixed was through calling the `WithViper()` method on `initClientCtx`. Reference: https://github.com/cosmos/cosmos-sdk/issues/13695#issuecomment-1331833185