### PR TITLE
feat: support for Cosmos Ecosystem based wallet addresses in Verification Methods + verification Method Type condition rearrangements

### DIFF
--- a/cmd/hid-noded/cmd/debug_extensions.go
+++ b/cmd/hid-noded/cmd/debug_extensions.go
@@ -35,6 +35,7 @@ func secp256k1Cmd() *cobra.Command {
 
 	cmd.AddCommand(
 		secp256k1RandomCmd(),
+		secp256k1Bech32AddressCmd(),
 		secp256k1EthRandomCmd(),
 	)
 
@@ -72,6 +73,30 @@ func secp256k1RandomCmd() *cobra.Command {
 			}
 
 			_, err = fmt.Fprintln(cmd.OutOrStdout(), string(keyInfoJson))
+			return err
+		},
+	}
+
+	return cmd
+}
+
+func secp256k1Bech32AddressCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bech32-addr [base64-encoded-public-key] [prefix]",
+		Short: "Converts a compressed base64 encoded secp256k1 public key to bech32 address",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			base64PubKey := args[0]
+			addrPrefix := args[1]
+
+			publicKeyBytes, err := base64.StdEncoding.DecodeString(base64PubKey)
+			if err != nil {
+				panic(err)
+			}
+
+			bech32address := publicKeyToBech32Address(addrPrefix, publicKeyBytes)
+
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), bech32address)
 			return err
 		},
 	}

--- a/cmd/hid-noded/cmd/debug_extensions_utils.go
+++ b/cmd/hid-noded/cmd/debug_extensions_utils.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"golang.org/x/crypto/ripemd160" //nolint: staticcheck
+
+	bech32 "github.com/cosmos/cosmos-sdk/types/bech32"
+)
+
+// publicKeyToBech32Address converts publicKey byteArray to Bech32 encoded blockchain address
+func publicKeyToBech32Address(addressPrefix string, pubKeyBytes []byte) string {
+	// Throw error if the length of secp256k1 publicKey is not 33
+	if len(pubKeyBytes) != 33 {
+		panic(fmt.Sprintf("invalid secp256k1 public key length %v", len(pubKeyBytes)))
+	}
+
+	// Hash pubKeyBytes as: RIPEMD160(SHA256(public_key_bytes))
+	pubKeySha256Hash := sha256.Sum256(pubKeyBytes)
+	ripemd160hash := ripemd160.New()
+	ripemd160hash.Write(pubKeySha256Hash[:])
+	addressBytes := ripemd160hash.Sum(nil)
+
+	// Convert addressBytes to bech32 encoded address
+	address, err := bech32.ConvertAndEncode(addressPrefix, addressBytes)
+	if err != nil {
+		panic(err)
+	}
+	return address
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/tendermint/spm v0.1.9
 	github.com/tendermint/tendermint v0.34.23
 	github.com/tendermint/tm-db v0.6.7
+	golang.org/x/crypto v0.1.0
 	google.golang.org/genproto v0.0.0-20221014213838-99cd37c6964a
 	google.golang.org/grpc v1.50.1
 )
@@ -115,7 +116,6 @@ require (
 	github.com/tendermint/go-amino v0.16.0 // indirect
 	github.com/zondax/hid v0.9.0 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
-	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect

--- a/tests/e2e/ssi_tests/README.md
+++ b/tests/e2e/ssi_tests/README.md
@@ -1,19 +1,3 @@
-# SSI Module E2E Tests
-
-Following scenarios are covered for E2E testing:
-
-`TC-1`: A simple SSI flow where three elements of SSI (DID Document, Schema Document and Credential Status Document).<br>
-`TC-2`: Controller DID attempts to create Credential Schema and Credential Status Documents on behalf of Parent DID.<br>
-`TC-3`: Multiple Controller DID attempt to create Credential Schema and Credential Status Documents on behalf of Parent DID.<br>
-`TC-4`: Non-Controller DID attempts to create Credential Schema and Credential Status Documents on behalf of Parent DID (Invalid Case).<br>
-`TC-5`: Non-Controller DID attempts to update a DID Document (Invalid Case).<br>
-`TC-6`: Controller DID attempts to update the Parent DID Document.<br>
-`TC-7`: Parent DID adds multiple DIDs in its controller group, and removes itself. One of the controllers and the Parent DID attemps to change the DID Document.<br>
-`TC-8`: Deactivated DID attempts to create Schema and Credential Status Documents.<br>
-`TC-9`: `x/ssi` module related transactions, using `secp256k1` keypair.<br>
-`TC-10`: Test scenarios for `blockchainAccountId`.<br>
-`TC-11`: `x/ssi` module related transactions, using ethereum based `secp256k1` keypair.<br>
-
 ## Run Tests
 
 Run the following to run tests

--- a/tests/e2e/ssi_tests/generate_doc.py
+++ b/tests/e2e/ssi_tests/generate_doc.py
@@ -3,7 +3,8 @@ import sys
 sys.path.insert(1, os.getcwd())
 
 import json
-from utils import run_command, generate_document_id, get_document_signature
+from utils import run_command, generate_document_id, get_document_signature, \
+    secp256k1_pubkey_to_address
 
 def generate_did_document(key_pair, algo="ed25519"):
     base_document = {
@@ -38,6 +39,11 @@ def generate_did_document(key_pair, algo="ed25519"):
     }
     if algo == "recover-eth":
         verification_method["blockchainAccountId"] = "eip155:1:" + key_pair["ethereum_address"]
+    elif algo == "secp256k1":
+
+        verification_method["blockchainAccountId"] = "cosmos:jagrat:" + \
+            secp256k1_pubkey_to_address(key_pair["pub_key_base_64"], "hid")
+        verification_method["publicKeyMultibase"] = key_pair["pub_key_multibase"]
     else:
         verification_method["publicKeyMultibase"] = key_pair["pub_key_multibase"]
     

--- a/tests/e2e/ssi_tests/run.py
+++ b/tests/e2e/ssi_tests/run.py
@@ -29,6 +29,9 @@ def run_all_tests():
     schema_test()
     deactivate_did()
     credential_status_test()
+    caip10_ethereum_support_test()
+    caip10_cosmos_support_test()
+    vm_type_test()
 
     print("============= 😃️ All test cases completed successfully ============== \n")
 

--- a/tests/e2e/ssi_tests/utils.py
+++ b/tests/e2e/ssi_tests/utils.py
@@ -103,3 +103,8 @@ def get_document_signature(doc: dict, doc_type: str, key_pair: dict, algo: str =
     cmd_string = f"hid-noded debug sign-ssi-doc {doc_cmd} '{json.dumps(doc)}' {private_key} {algo}"
     signature, _ = run_command(cmd_string)
     return signature
+
+def secp256k1_pubkey_to_address(pub_key, prefix):
+    cmd_string = f"hid-noded debug secp256k1 bech32-addr {pub_key} {prefix}"
+    addr, _ = run_command(cmd_string)
+    return addr

--- a/x/ssi/types/common.go
+++ b/x/ssi/types/common.go
@@ -12,6 +12,16 @@ var VerificationKeySignatureMap = map[string]string{
 	EcdsaSecp256k1RecoveryMethod2020:  "EcdsaSecp256k1RecoverySignature2020",
 }
 
+var supportedVerificationMethodTypes []string = func() []string {
+	result := []string{}
+
+	for vmType := range VerificationKeySignatureMap {
+		result = append(result, vmType)
+	}
+
+	return result
+}()
+
 // Supported Service Types
 var SupportedServiceTypes = []string{
 	"LinkedDomains",
@@ -21,14 +31,42 @@ var SupportedServiceTypes = []string{
 const DocumentIdentifierDid = "did"
 const DidMethod = "hid"
 
-// Supported CAIP-10 prefixes
-const EIP155 string = "eip155"
+// CAIP-10 prefixes
+const EthereumCAIP10Prefix string = "eip155" // Ethereum Based Chains
+const CosmosCAIP10Prefix string = "cosmos"   // Cosmos Based Chains
 
-// Support Client Specs
+// Supported CAIP-10 prefixes
+var CAIP10PrefixForEcdsaSecp256k1RecoveryMethod2020 []string = []string{
+	EthereumCAIP10Prefix,
+}
+
+var CAIP10PrefixForEcdsaSecp256k1VerificationKey2019 []string = []string{
+	CosmosCAIP10Prefix,
+}
+
 const ADR036Spec string = "cosmos-ADR036"
 const PersonalSignSpec string = "eth-personalSign"
 
+// Supported Client Specs
 var SupportedClientSpecs []string = []string{
 	ADR036Spec,
 	PersonalSignSpec,
+}
+
+// Map between supported cosmos chain-id and their respective blockhchain address prefix
+var CosmosCAIP10ChainIdBech32PrefixMap = map[string]string{
+	// Mainnet Chains
+	"cosmoshub-4":                "cosmos",
+	"osmosis-1":                  "osmo",
+	"akashnet-2":                 "akash",
+	"stargaze-1":                 "stars",
+	"core-1":                     "persistence",
+	"crypto-org-chain-mainnet-1": "cro",
+
+	// Testnet Chains
+	"theta-testnet-001": "cosmos",
+	"osmo-test-4":       "osmo",
+	"elgafar-1":         "stars",
+	"test-core-1":       "persistence",
+	"jagrat":            "hid",
 }

--- a/x/ssi/verification/address.go
+++ b/x/ssi/verification/address.go
@@ -1,0 +1,31 @@
+package verification
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"golang.org/x/crypto/ripemd160" // nolint: staticcheck
+
+	bech32 "github.com/cosmos/cosmos-sdk/types/bech32"
+)
+
+// publicKeyToCosmosBech32Address converts publicKey byteArray to Bech32 encoded blockchain address
+func publicKeyToCosmosBech32Address(addressPrefix string, pubKeyBytes []byte) string {
+	// Throw error if the length of secp256k1 publicKey is not 33
+	if len(pubKeyBytes) != 33 {
+		panic(fmt.Sprintf("invalid secp256k1 public key length %v", len(pubKeyBytes)))
+	}
+
+	// Hash pubKeyBytes as: RIPEMD160(SHA256(public_key_bytes))
+	pubKeySha256Hash := sha256.Sum256(pubKeyBytes)
+	ripemd160hash := ripemd160.New()
+	ripemd160hash.Write(pubKeySha256Hash[:])
+	addressBytes := ripemd160hash.Sum(nil)
+
+	// Convert addressBytes to bech32 encoded address
+	address, err := bech32.ConvertAndEncode(addressPrefix, addressBytes)
+	if err != nil {
+		panic(err)
+	}
+	return address
+}

--- a/x/ssi/verification/caip10.go
+++ b/x/ssi/verification/caip10.go
@@ -1,6 +1,7 @@
 package verification
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/hypersign-protocol/hid-node/x/ssi/types"
@@ -13,15 +14,37 @@ func getBlockchainAddress(blockchainAccountId string) string {
 	return blockchainAddress
 }
 
-// Extracts the CAIP-10 prefix from blockchainAccountId and returns the chain spec
-func getCAIP10Chain(blockchainAccountId string) string {
-	segments := strings.Split(blockchainAccountId, ":")
-	userPrefix := strings.Join(segments[0:len(segments)-1], ":")
+// getChainIdFromBlockchainAccountId extracts chain from blockchainAccountId
+func getChainIdFromBlockchainAccountId(blockchainAccountId string) string {
+	chainIdIdx := 1
 
-	// Ethereum based chain (EIP-155) check
-	if strings.HasPrefix(userPrefix, types.EIP155) {
-		return types.EIP155
+	blockchainAccountIdElements := strings.Split(blockchainAccountId, ":")
+	blockchainChainId := blockchainAccountIdElements[chainIdIdx]
+	return blockchainChainId
+}
+
+// Extracts the CAIP-10 prefix from blockchainAccountId and returns the chain spec
+func getCAIP10Prefix(blockchainAccountId string) (string, error) {
+	segments := strings.Split(blockchainAccountId, ":")
+
+	// Validate blockchainAccountId
+	if len(segments) != 3 {
+		return "", fmt.Errorf(
+			"invalid CAIP-10 format for blockchainAccountId '%v'. Please refer: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md",
+			blockchainAccountId,
+		)
+	}
+
+	// Prefix check
+	if segments[0] == types.EthereumCAIP10Prefix {
+		return types.EthereumCAIP10Prefix, nil
+	} else if segments[0] == types.CosmosCAIP10Prefix {
+		return types.CosmosCAIP10Prefix, nil
 	} else {
-		return ""
+		return "", fmt.Errorf(
+			"unsupported CAIP-10 prefix in blockchainAccountId '%v'. Supported CAIP-10 prefixes: %v",
+			blockchainAccountId,
+			types.CAIP10PrefixForEcdsaSecp256k1RecoveryMethod2020,
+		)
 	}
 }

--- a/x/ssi/verification/signature_verification.go
+++ b/x/ssi/verification/signature_verification.go
@@ -16,7 +16,7 @@ func VerifySignatureOfEveryController(
 		}
 		err := verifyAll(vmList, didDoc)
 		if err != nil {
-			return fmt.Errorf("need every signature for controller %s to be valid", controller)
+			return fmt.Errorf("%s: need every signature for controller %s to be valid", err.Error(), controller)
 		}
 	}
 	return nil


### PR DESCRIPTION
- Users can add their Cosmos based bech32 wallet addresses in their DID Documents. The format for blockchainAccountId is `cosmos:<chain-id>:<bech-32 encoded wallet address>`. Currently, the support is limited to the following chains:
  - **Mainnet Chains**:
     - Cosmos Hub (cosmoshub-4)
     - Osmosis (osmosis-1)
     - Akash Network (akashnet-2)
     - Persistence (core-1)
     - Crypto.org (crypto-org-chain-mainnet-1)
   - **Testnet Chains**
     - Cosmos Hub (theta-testnet-001)
     - Osmosis (osmo-test-4)
     - Stargaze (elgafar-1)
     - Persistence (test-core-1)
     - Hypersign Testnet (jagrat)

- The branching of Verification Method Types is done based on the following relationships between itself and attributes such as `blockchainAccountId` and `publicKeyMultibase`

| ↓ VM Type / VM Attributes →| publicKeyMultibase | blockchainAccountId | Valid/Invalid ? |
| --------------------------------- | -------------------------- | ---------------------------- | ---------------- |
| Ed25519VerificationKey2020 | Present | Present | **Invalid** |
| | Absent | Present | **Invalid** |
| | Present | Absent | **Valid** |
| EcdsaSecp256k1VerificationKey2019 | Present | Present | **Valid** |
| | Absent | Present | **Invalid** |
| | Present | Absent | **Valid** |
| EcdsaSecp256k1RecoveryMethod2020 | Present | Present | **Invalid** |
| | Absent | Present | **Valid** |
| | Present | Absent | **Invalid** |

- This PR can only be merged after the successful merging of https://github.com/hypersign-protocol/hid-node/pull/338

Test Report has been attached below
[e2e_ssi_module_test_report.txt](https://github.com/hypersign-protocol/hid-node/files/10978378/e2e_ssi_module_test_report.txt)

