### PR TITLE
fix: clientSpec RPC param is optional

### DIFF
--- a/x/ssi/client/cli/tx_ssi.go
+++ b/x/ssi/client/cli/tx_ssi.go
@@ -128,9 +128,6 @@ func CmdCreateSchema() *cobra.Command {
 				SchemaDoc:   &schemaDoc,
 				SchemaProof: &schemaProof,
 				Creator:     clientCtx.GetFromAddress().String(),
-				ClientSpec: &types.ClientSpec{
-					Type: "",
-				},
 			}
 
 			if err := msg.ValidateBasic(); err != nil {
@@ -227,9 +224,6 @@ func CmdRegisterCredentialStatus() *cobra.Command {
 				CredentialStatus: &credentialStatus,
 				Proof:            &proof,
 				Creator:          clientCtx.GetFromAddress().String(),
-				ClientSpec: &types.ClientSpec{
-					Type: "",
-				},
 			}
 
 			if err := msg.ValidateBasic(); err != nil {

--- a/x/ssi/client/cli/tx_utils.go
+++ b/x/ssi/client/cli/tx_utils.go
@@ -109,9 +109,6 @@ func getSignatures(cmd *cobra.Command, message []byte, cmdArgs []string) ([]*typ
 		// Get the VM Ids
 		signInfoList = append(signInfoList, &types.SignInfo{
 			VerificationMethodId: didSigningElementsList[i].VerificationMethodId,
-			ClientSpec: &types.ClientSpec{
-				Type: "",
-			},
 		})
 
 		// Sign based on the Signing Algorithm

--- a/x/ssi/verification/client_spec.go
+++ b/x/ssi/verification/client_spec.go
@@ -52,22 +52,19 @@ func getPersonalSignSpecDocBytes(ssiMsg types.SsiMsg) ([]byte, error) {
 
 // Get the updated marshaled SSI document for the respective ClientSpec
 func getDocBytesByClientSpec(ssiMsg types.SsiMsg, extendedVm *types.ExtendedVerificationMethod) ([]byte, error) {
-	if extendedVm.ClientSpec == nil {
-		return nil, fmt.Errorf("clientSpec cannot be nil for verificationMethod %v", extendedVm.Id)
-	}
-
-	switch extendedVm.ClientSpec.Type {
-	case types.ADR036ClientSpec:
-		return getCosmosADR036SignDocBytes(ssiMsg, extendedVm.ClientSpec)
-	case types.PersonalSignClientSpec:
-		return getPersonalSignSpecDocBytes(ssiMsg)
-	// Non-ClientSpec RPC Request. Return marshaled SSI document as-is
-	case "":
+	if extendedVm.ClientSpec != nil {
+		switch extendedVm.ClientSpec.Type {
+		case types.ADR036ClientSpec:
+			return getCosmosADR036SignDocBytes(ssiMsg, extendedVm.ClientSpec)
+		case types.PersonalSignClientSpec:
+			return getPersonalSignSpecDocBytes(ssiMsg)
+		default:
+			return nil, fmt.Errorf(
+				"supported clientSpecs: %v",
+				types.SupportedClientSpecs,
+			)
+		}
+	} else {
 		return ssiMsg.GetSignBytes(), nil
-	default:
-		return nil, fmt.Errorf(
-			"supported clientSpecs: %v",
-			types.SupportedClientSpecs,
-		)
 	}
 }


### PR DESCRIPTION
Any Transaction that doesn't require clientSpec input, need not explicitly need to specify clientSpec parmas as empty strings