### PR TITLE
Fix: Single DIDDoc update operation

### DIFF
--- a/tests/e2e/ssi_tests/e2e_tests.py
+++ b/tests/e2e/ssi_tests/e2e_tests.py
@@ -143,6 +143,52 @@ def create_did_test():
 
     print("--- Test Completed ---\n")
 
+
+def run_something():
+    print("11. PASS: Jenny creates herself a DID with empty Controller list. She then attempts to update the DIDDoc by changing the context field and passes her signature only.\n")
+    kp_jenny = generate_key_pair()
+    kp_alice = generate_key_pair()
+
+    signers = []
+    did_doc_string = generate_did_document(kp_jenny)
+    did_doc_string["controller"] = []
+    did_doc_jenny = did_doc_string["id"]
+    did_doc_jenny_vm = did_doc_string["verificationMethod"][0]
+    signPair_jenny = {
+        "kp": kp_jenny,
+        "verificationMethodId": did_doc_jenny_vm["id"],
+        "signing_algo": "ed25519"
+    }
+    signers.append(signPair_jenny)
+    create_tx_cmd = form_did_create_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
+    run_blockchain_command(create_tx_cmd, f"Registering of Jenny's DID with Id: {did_doc_jenny}")
+
+    signers = []
+    did_doc_string_alice = generate_did_document(kp_alice)
+    new_vm = did_doc_string_alice["verificationMethod"][0]
+    new_vm_id = did_doc_string["verificationMethod"][0]["id"] + "news"
+    new_vm["id"] = new_vm_id
+    new_vm["controller"] = did_doc_string["id"]   
+
+    did_doc_string["verificationMethod"] = [
+        did_doc_string["verificationMethod"][0],
+        new_vm,
+    ]
+    signPair_jenny_1 = {
+        "kp": kp_jenny,
+        "verificationMethodId": did_doc_jenny_vm["id"],
+        "signing_algo": "ed25519"
+    }
+    signPair_jenny_2 = {
+        "kp": kp_alice,
+        "verificationMethodId": new_vm_id,
+        "signing_algo": "ed25519"
+    }
+    signers.append(signPair_jenny_1)
+    signers.append(signPair_jenny_2)
+    update_tx_cmd = form_did_update_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
+    run_blockchain_command(update_tx_cmd, f"Jenny (controller) attempts to update Tx")
+
 # TC - II : Update DID scenarios
 def update_did_test():
     print("\n--- Update DID Test ---\n") 
@@ -350,6 +396,50 @@ def update_did_test():
     signers = []
     did_doc_string["context"] = ["yo"]
     signers.append(signPair_jenny)
+    update_tx_cmd = form_did_update_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
+    run_blockchain_command(update_tx_cmd, f"Jenny (controller) attempts to update Tx")
+
+    print("12. PASS: Jenny creates herself a DID with empty Controller list. She then attempts to update the DIDDoc by adding a new Verification method. She passes signatures for both new and old VMs\n")
+    kp_jenny = generate_key_pair()
+    kp_jenny_2 = generate_key_pair()
+
+    signers = []
+    did_doc_string = generate_did_document(kp_jenny)
+    did_doc_string["controller"] = []
+    did_doc_jenny = did_doc_string["id"]
+    did_doc_jenny_vm = did_doc_string["verificationMethod"][0]
+    signPair_jenny = {
+        "kp": kp_jenny,
+        "verificationMethodId": did_doc_jenny_vm["id"],
+        "signing_algo": "ed25519"
+    }
+    signers.append(signPair_jenny)
+    create_tx_cmd = form_did_create_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
+    run_blockchain_command(create_tx_cmd, f"Registering of Jenny's DID with Id: {did_doc_jenny}")
+
+    signers = []
+    did_doc_string_alice = generate_did_document(kp_jenny_2)
+    new_vm = did_doc_string_alice["verificationMethod"][0]
+    new_vm_id = did_doc_string["verificationMethod"][0]["id"] + "news"
+    new_vm["id"] = new_vm_id
+    new_vm["controller"] = did_doc_string["id"]
+
+    did_doc_string["verificationMethod"] = [
+        did_doc_string["verificationMethod"][0],
+        new_vm,
+    ]
+    signPair_jenny_1 = {
+        "kp": kp_jenny,
+        "verificationMethodId": did_doc_jenny_vm["id"],
+        "signing_algo": "ed25519"
+    }
+    signPair_jenny_2 = {
+        "kp": kp_jenny_2,
+        "verificationMethodId": new_vm_id,
+        "signing_algo": "ed25519"
+    }
+    signers.append(signPair_jenny_1)
+    signers.append(signPair_jenny_2)
     update_tx_cmd = form_did_update_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
     run_blockchain_command(update_tx_cmd, f"Jenny (controller) attempts to update Tx")
 

--- a/tests/e2e/ssi_tests/e2e_tests.py
+++ b/tests/e2e/ssi_tests/e2e_tests.py
@@ -143,52 +143,6 @@ def create_did_test():
 
     print("--- Test Completed ---\n")
 
-
-def run_something():
-    print("11. PASS: Jenny creates herself a DID with empty Controller list. She then attempts to update the DIDDoc by changing the context field and passes her signature only.\n")
-    kp_jenny = generate_key_pair()
-    kp_alice = generate_key_pair()
-
-    signers = []
-    did_doc_string = generate_did_document(kp_jenny)
-    did_doc_string["controller"] = []
-    did_doc_jenny = did_doc_string["id"]
-    did_doc_jenny_vm = did_doc_string["verificationMethod"][0]
-    signPair_jenny = {
-        "kp": kp_jenny,
-        "verificationMethodId": did_doc_jenny_vm["id"],
-        "signing_algo": "ed25519"
-    }
-    signers.append(signPair_jenny)
-    create_tx_cmd = form_did_create_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
-    run_blockchain_command(create_tx_cmd, f"Registering of Jenny's DID with Id: {did_doc_jenny}")
-
-    signers = []
-    did_doc_string_alice = generate_did_document(kp_alice)
-    new_vm = did_doc_string_alice["verificationMethod"][0]
-    new_vm_id = did_doc_string["verificationMethod"][0]["id"] + "news"
-    new_vm["id"] = new_vm_id
-    new_vm["controller"] = did_doc_string["id"]   
-
-    did_doc_string["verificationMethod"] = [
-        did_doc_string["verificationMethod"][0],
-        new_vm,
-    ]
-    signPair_jenny_1 = {
-        "kp": kp_jenny,
-        "verificationMethodId": did_doc_jenny_vm["id"],
-        "signing_algo": "ed25519"
-    }
-    signPair_jenny_2 = {
-        "kp": kp_alice,
-        "verificationMethodId": new_vm_id,
-        "signing_algo": "ed25519"
-    }
-    signers.append(signPair_jenny_1)
-    signers.append(signPair_jenny_2)
-    update_tx_cmd = form_did_update_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
-    run_blockchain_command(update_tx_cmd, f"Jenny (controller) attempts to update Tx")
-
 # TC - II : Update DID scenarios
 def update_did_test():
     print("\n--- Update DID Test ---\n") 
@@ -399,13 +353,12 @@ def update_did_test():
     update_tx_cmd = form_did_update_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
     run_blockchain_command(update_tx_cmd, f"Jenny (controller) attempts to update Tx")
 
-    print("12. PASS: Jenny creates herself a DID with empty Controller list. She then attempts to update the DIDDoc by adding a new Verification method. She passes signatures for both new and old VMs\n")
+    print("12. FAIL: Jenny creates a DID. She then attempts to update the DIDDoc by adding a new Verification method. She passes signature only for old VM\n")
     kp_jenny = generate_key_pair()
     kp_jenny_2 = generate_key_pair()
 
     signers = []
     did_doc_string = generate_did_document(kp_jenny)
-    did_doc_string["controller"] = []
     did_doc_jenny = did_doc_string["id"]
     did_doc_jenny_vm = did_doc_string["verificationMethod"][0]
     signPair_jenny = {
@@ -439,9 +392,26 @@ def update_did_test():
         "signing_algo": "ed25519"
     }
     signers.append(signPair_jenny_1)
+    update_tx_cmd = form_did_update_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
+    run_blockchain_command(update_tx_cmd, f"Jenny attempts to update the DIDDoc with only old VM's signature", True)
+
+    print("13. PASS: Jenny attempts to update the same didDoc by passing signatures for both old and new verification methods\n")
+
+    signers = []
+    signers.append(signPair_jenny_1)
     signers.append(signPair_jenny_2)
     update_tx_cmd = form_did_update_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
-    run_blockchain_command(update_tx_cmd, f"Jenny (controller) attempts to update Tx")
+    run_blockchain_command(update_tx_cmd, f"Jenny attempts to update the DIDDoc with both new and old VM's signature")
+    
+    print("14. PASS: Jenny removes the inital verification method she had added. She passes only one signature corresponding to the lastest VM")
+
+    did_doc_string["verificationMethod"] = [
+        new_vm,
+    ]
+    signers = []
+    signers.append(signPair_jenny_1)
+    update_tx_cmd = form_did_update_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
+    run_blockchain_command(update_tx_cmd, f"Jenny attempts to remove Verification Method using signature corresponding to other verification method")
 
     print("--- Test Completed ---\n")
 

--- a/tests/e2e/ssi_tests/run.py
+++ b/tests/e2e/ssi_tests/run.py
@@ -24,14 +24,15 @@ def generate_report(func):
 def run_all_tests():
     print("============= 🔧️ Running all x/ssi e2e tests ============== \n")
     
-    create_did_test()
+    # create_did_test()
     update_did_test()
-    schema_test()
-    deactivate_did()
-    credential_status_test()
-    caip10_ethereum_support_test()
-    caip10_cosmos_support_test()
-    vm_type_test()
+    # schema_test()
+    # deactivate_did()
+    # credential_status_test()
+    # caip10_ethereum_support_test()
+    # caip10_cosmos_support_test()
+    # vm_type_test()
+    #run_something()
 
     print("============= 😃️ All test cases completed successfully ============== \n")
 

--- a/tests/e2e/ssi_tests/run.py
+++ b/tests/e2e/ssi_tests/run.py
@@ -24,15 +24,14 @@ def generate_report(func):
 def run_all_tests():
     print("============= 🔧️ Running all x/ssi e2e tests ============== \n")
     
-    # create_did_test()
+    create_did_test()
     update_did_test()
-    # schema_test()
-    # deactivate_did()
-    # credential_status_test()
-    # caip10_ethereum_support_test()
-    # caip10_cosmos_support_test()
-    # vm_type_test()
-    #run_something()
+    schema_test()
+    deactivate_did()
+    credential_status_test()
+    caip10_ethereum_support_test()
+    caip10_cosmos_support_test()
+    vm_type_test()
 
     print("============= 😃️ All test cases completed successfully ============== \n")
 

--- a/x/ssi/keeper/msg_server.go
+++ b/x/ssi/keeper/msg_server.go
@@ -88,6 +88,7 @@ func (k msgServer) formMustControllerVmListMap(ctx sdk.Context,
 				if presentInControllerMap {
 					vmExtended := types.CreateExtendedVerificationMethod(vmMap[vmId], sign)
 					controllerMap[controller] = append(controllerMap[controller], vmExtended)
+					delete(inputSignMap, vmId)
 				}
 				// Check for VM from the respective controller's DID Doc
 			} else {
@@ -99,6 +100,7 @@ func (k msgServer) formMustControllerVmListMap(ctx sdk.Context,
 				if presentInControllerMap {
 					vmExtended := types.CreateExtendedVerificationMethod(vmState, sign)
 					controllerMap[controller] = append(controllerMap[controller], vmExtended)
+					delete(inputSignMap, vmId)
 				}
 			}
 		}


### PR DESCRIPTION
The PR aims to fix the issues related DID Document Update process. Following tests cases covers the issue:

1. FAIL: Jenny creates a DID. She then attempts to update the DIDDoc by adding a new Verification method. She passes signature only for old VM.

2. PASS: Jenny attempts to update the same didDoc by passing signatures for both old and new verification methods.

3. PASS: Jenny removes the initial verification method she had added. She passes only one signature corresponding to the latest VM