### PR TITLE
hotfix: downgrade docker version to 20.04 in `release` worklow to fix GLIBC version issue found in `hid-noded` binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   release-binaries-github:
     name: Release Binaries to Github
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
It was observed that the binaries released from Github Actions encountered the following error, while runnin `hid-noded` command.

```
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found
```

The solution was to downgrade the docker version on Github Actions `release` workflow from `latest` to `20.04`. This approach was performed on a temporary fork of `hid-node`. All the tests were run to ensure blockchain transactions worked fine .