### PR TITLE
fix: added temporary validation for `EcdsaSecp256k1VerificationKey2019` VM type to allow duplicate `publicKeyMultibase` only when `blockchainAccountId`s are provided

### DIFF
--- a/tests/e2e/ssi_tests/generate_doc.py
+++ b/tests/e2e/ssi_tests/generate_doc.py
@@ -6,7 +6,7 @@ import json
 from utils import run_command, generate_document_id, get_document_signature, \
     secp256k1_pubkey_to_address
 
-def generate_did_document(key_pair, algo="ed25519"):
+def generate_did_document(key_pair, algo="ed25519", bech32prefix="hid"):
     base_document = {
         "context" : [
             "https://www.w3.org/ns/did/v1"
@@ -41,8 +41,15 @@ def generate_did_document(key_pair, algo="ed25519"):
         verification_method["blockchainAccountId"] = "eip155:1:" + key_pair["ethereum_address"]
     elif algo == "secp256k1":
 
-        verification_method["blockchainAccountId"] = "cosmos:jagrat:" + \
-            secp256k1_pubkey_to_address(key_pair["pub_key_base_64"], "hid")
+        if bech32prefix == "hid":
+            verification_method["blockchainAccountId"] = "cosmos:jagrat:" + \
+                secp256k1_pubkey_to_address(key_pair["pub_key_base_64"], bech32prefix)
+        elif bech32prefix == "osmo":
+            verification_method["blockchainAccountId"] = "cosmos:osmosis-1:" + \
+                secp256k1_pubkey_to_address(key_pair["pub_key_base_64"], bech32prefix)
+        else:
+            raise Exception("unsupported bech32 prefix " + bech32prefix)
+    
         verification_method["publicKeyMultibase"] = key_pair["pub_key_multibase"]
     else:
         verification_method["publicKeyMultibase"] = key_pair["pub_key_multibase"]

--- a/x/ssi/types/diddoc_validation.go
+++ b/x/ssi/types/diddoc_validation.go
@@ -135,8 +135,8 @@ func verificationKeyCheck(vm *VerificationMethod) error {
 	return nil
 }
 
-// checkDuplicateId return a duplicate Id from the list, if found
-func checkDuplicateId(list []string) string {
+// checkDuplicateItems return a duplicate Id from the list, if found
+func checkDuplicateItems(list []string) string {
 	presentMap := map[string]bool{}
 	for idx := range list {
 		if _, present := presentMap[list[idx]]; !present {
@@ -175,7 +175,7 @@ func validateServices(services []*Service) error {
 	for _, service := range services {
 		serviceIdList = append(serviceIdList, service.Id)
 	}
-	if duplicateId := checkDuplicateId(serviceIdList); duplicateId != "" {
+	if duplicateId := checkDuplicateItems(serviceIdList); duplicateId != "" {
 		return fmt.Errorf("duplicate service found with Id: %s ", duplicateId)
 	}
 
@@ -216,19 +216,42 @@ func validateVerificationMethods(vms []*VerificationMethod) error {
 	vmIdList := []string{}
 	publicKeyMultibaseList := []string{}
 	blockchainAccountIdList := []string{}
+	
+	var pubKeyMultibaseBlockchainAccIdMap map[string]bool = map[string]bool{}
 
 	for _, vm := range vms {
 		vmIdList = append(vmIdList, vm.Id)
-		publicKeyMultibaseList = append(publicKeyMultibaseList, vm.PublicKeyMultibase)
+		
+		if vm.Type == EcdsaSecp256k1VerificationKey2019 {
+			if _, present := pubKeyMultibaseBlockchainAccIdMap[vm.PublicKeyMultibase]; present {
+				// TODO: Following is a temporary measure, where we will be allowing duplicate publicKeyMultibase values
+				// for type EcdsaSecp256k1VerificationKey2019, provided if blockchainAccountId field is populated. This is done since
+				// one secp256k1 key pair from Keplr wallet can have multiple blockchain addresses depending upon the bech32
+				// prefix. This will eventually be removed once the successful recovery of public key from the `signEthereum()`
+				// generated signature is figured out.
+				if vm.BlockchainAccountId == "" {
+					return fmt.Errorf(
+						"duplicate publicKeyMultibase of type EcdsaSecp256k1VerificationKey2019 without blockchainAccountId is not allowed: %s ", 
+						vm.PublicKeyMultibase,
+					)
+				}
+			} else {
+				pubKeyMultibaseBlockchainAccIdMap[vm.PublicKeyMultibase] = true
+			}
+		} else {
+			publicKeyMultibaseList = append(publicKeyMultibaseList, vm.PublicKeyMultibase)
+		}
+		
 		blockchainAccountIdList = append(blockchainAccountIdList, vm.BlockchainAccountId)
 	}
-	if duplicateId := checkDuplicateId(vmIdList); duplicateId != "" {
+
+	if duplicateId := checkDuplicateItems(vmIdList); duplicateId != "" {
 		return fmt.Errorf("duplicate verification method Id found: %s ", duplicateId)
 	}
-	if duplicateKey := checkDuplicateId(publicKeyMultibaseList); duplicateKey != "" {
+	if duplicateKey := checkDuplicateItems(publicKeyMultibaseList); duplicateKey != "" {
 		return fmt.Errorf("duplicate publicKeyMultibase found: %s ", duplicateKey)
 	}
-	if duplicateKey := checkDuplicateId(blockchainAccountIdList); duplicateKey != "" {
+	if duplicateKey := checkDuplicateItems(blockchainAccountIdList); duplicateKey != "" {
 		return fmt.Errorf("duplicate blockchainAccountId found: %s ", duplicateKey)
 	}
 


### PR DESCRIPTION
Closes: https://github.com/hypersign-protocol/hid-node/issues/348

Following Cases are covered in this PR:

| Scenario | Whether it should PASS or FAIL ? |
| ------------ | ------------------------------------------ |
| Registering a DID with two VM of type EcdsaSecp256k1VerificationKey2019 with duplicate publicKeyMultibase and different blockchain account Id | PASS |
| Registering a DID with two VM of type EcdsaSecp256k1VerificationKey2019 with duplicate publicKeyMultibase but one of them is without a blockchain account id | PASS |
| Registering a DID with two VM of type EcdsaSecp256k1VerificationKey2019 with duplicate publicKeyMultibase and duplicate blockchainAccountId | FAIL |
| Registering a DID with two VM of type EcdsaSecp256k1VerificationKey2019 with duplicate publicKeyMultibase and no blockchainAccountId in either of them | FAIL |
|  User tries to register a DID Document with duplicate `publicKeyMultibase` of type Ed25519VerificationKey2020 | FAIL |