### PR TITLE
refactor: restricted CAIP-10 support for ethereum blockchain addresses to specific chains

### DIFF
--- a/tests/e2e/ssi_tests/e2e_tests.py
+++ b/tests/e2e/ssi_tests/e2e_tests.py
@@ -657,6 +657,8 @@ def caip10_ethereum_support_test():
         "eip155:1",
         "eip155:::::23",
         "eip155::0x1234567"
+        "eip155:1000231432:0x23",
+        "eip155:jagrat:0x23"
     ]
 
     for invalid_blockchain_id in invalid_blockchain_account_ids:
@@ -673,7 +675,7 @@ def caip10_ethereum_support_test():
         }
         signers.append(signPair)
         create_tx_cmd = form_did_create_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
-        run_blockchain_command(create_tx_cmd, f"Registering a DID Document with an invalid blockchainAccountId: {invalid_blockchain_id}", True)
+        run_blockchain_command(create_tx_cmd, f"Registering a DID Document with an invalid blockchainAccountId: {invalid_blockchain_id}", True, True)
     
     print("Registering a DID with a VM of type EcdsaSecp256k1SignatureRecovery2020 having publicKeyMultibase attribute populated")
     kp = generate_key_pair(algo=kp_algo)
@@ -745,7 +747,7 @@ def caip10_cosmos_support_test():
         signers.append(signPair)
 
         create_tx_cmd = form_did_create_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
-        run_blockchain_command(create_tx_cmd, f"Registering a DID Document with an invalid blockchainAccountId: {invalid_blockchain_id}", True)
+        run_blockchain_command(create_tx_cmd, f"Registering a DID Document with an invalid blockchainAccountId: {invalid_blockchain_id}", True, True)
     
     print("Registering a DID with a VM of type EcdsaSecp256k1VerificationKey2019 having both publicKeyMultibase and blockchainAccountId attributes populated")
     kp = generate_key_pair(algo=kp_algo)
@@ -777,7 +779,7 @@ def caip10_cosmos_support_test():
     signers.append(signPair)
     
     create_tx_cmd = form_did_create_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
-    run_blockchain_command(create_tx_cmd, f"Registering DID with Id: {did_doc_id}", True)
+    run_blockchain_command(create_tx_cmd, f"Registering DID with Id: {did_doc_id}", True, True)
 
     print("--- Test Completed ---\n")
 

--- a/x/ssi/types/common.go
+++ b/x/ssi/types/common.go
@@ -53,6 +53,41 @@ var SupportedClientSpecs []string = []string{
 	PersonalSignClientSpec,
 }
 
+// Supported CAIP-10 Prefixes
+var SupportedCAIP10Prefixes = []string{
+	EthereumCAIP10Prefix,
+	CosmosCAIP10Prefix,
+}
+
+var SupportedCAIP10EthereumChainIds = []string{
+	// Ethereum-Based Mainnet Chains
+	"1",   // Ethereum Mainnet
+	"137", // Polygon Mainnet
+	"56",  // Binance Smart Chain
+
+	// Ethereum-Based Testnet Chains
+	"3",     // Ropsten (Ethereum Testnet)
+	"4",     // Rinkeby (Ethereum Testnet)
+	"5",     // Goerli (Ethereum Testnet)
+	"80001", // Polygon Mumbai Testnet
+	"97",    // Binance Smart Chain Testnet
+}
+
+var SupportedCAIP10CosmosChainIds = []string{
+	"cosmoshub-4",                // Cosmos Hub
+	"osmosis-1",                  // Osmosis
+	"akashnet-2",                 // Akash
+	"stargaze-1",                 // Stargaze
+	"core-1",                     // Persistence
+	"crypto-org-chain-mainnet-1", // Crypto.Org Chain
+
+	"theta-testnet-001", // Cosmos Hub Theta Testnet
+	"osmo-test-4",       // Osmosis Testnet
+	"elgafar-1",         // Stargaze Testnet
+	"test-core-1",       // Persistence Testnet
+	"jagrat",            // Hypersign Identity Network - Jagrat Testnet
+}
+
 // Map between supported cosmos chain-id and their respective blockhchain address prefix
 var CosmosCAIP10ChainIdBech32PrefixMap = map[string]string{
 	// Mainnet Chains
@@ -69,4 +104,10 @@ var CosmosCAIP10ChainIdBech32PrefixMap = map[string]string{
 	"elgafar-1":         "stars",
 	"test-core-1":       "persistence",
 	"jagrat":            "hid",
+}
+
+// Map between support CAIP-10 prefix and list of chain-ids
+var SupportedCAIP10PrefixChainIdsMap = map[string][]string{
+	EthereumCAIP10Prefix: SupportedCAIP10EthereumChainIds,
+	CosmosCAIP10Prefix:   SupportedCAIP10CosmosChainIds,
 }

--- a/x/ssi/types/diddoc_validation.go
+++ b/x/ssi/types/diddoc_validation.go
@@ -132,6 +132,14 @@ func verificationKeyCheck(vm *VerificationMethod) error {
 		return fmt.Errorf("unsupported verification method type: %v", supportedVerificationMethodTypes)
 	}
 
+	// validate blockchainAccountId
+	if vm.BlockchainAccountId != "" {
+		err := validateBlockchainAccountId(vm.BlockchainAccountId)
+		if err != nil {
+			return fmt.Errorf("invalid blockchainAccount Id %v: "+err.Error(), vm.BlockchainAccountId)
+		}
+	}
+
 	return nil
 }
 
@@ -264,6 +272,38 @@ func validateVmRelationships(didDoc *Did) error {
 					element,
 				)
 			}
+		}
+	}
+
+	return nil
+}
+
+func validateBlockchainAccountId(blockchainAccountId string) error {
+	blockchainId, err := NewBlockchainId(blockchainAccountId)
+	if err != nil {
+		return err
+	}
+
+	var validationErr error
+
+	// Check for supported CAIP-10 prefix
+	validationErr = blockchainId.ValidateSupportedCAIP10Prefix()
+	if validationErr != nil {
+		return validationErr
+	}
+
+	// Check for supported CAIP-10 chain-ids
+	validationErr = blockchainId.ValidateSupportChainId()
+	if validationErr != nil {
+		return validationErr
+	}
+
+	// Check for supported CAIP-10 bech32 prefix. Perform this validation
+	// only when the CAIP-10 prefix is "cosmos"
+	if blockchainId.CAIP10Prefix == CosmosCAIP10Prefix {
+		validationErr = blockchainId.ValidateSupportedBech32Prefix()
+		if validationErr != nil {
+			return validationErr
 		}
 	}
 

--- a/x/ssi/verification/address.go
+++ b/x/ssi/verification/address.go
@@ -10,10 +10,15 @@ import (
 )
 
 // publicKeyToCosmosBech32Address converts publicKey byteArray to Bech32 encoded blockchain address
-func publicKeyToCosmosBech32Address(addressPrefix string, pubKeyBytes []byte) string {
+func publicKeyToCosmosBech32Address(addressPrefix string, pubKeyBytes []byte) (string, error) {
 	// Throw error if the length of secp256k1 publicKey is not 33
 	if len(pubKeyBytes) != 33 {
-		panic(fmt.Sprintf("invalid secp256k1 public key length %v", len(pubKeyBytes)))
+		return "", fmt.Errorf("invalid secp256k1 public key length %v", len(pubKeyBytes))
+	}
+
+	// Throw an error if addressPrefix is empty
+	if addressPrefix == "" {
+		return "", fmt.Errorf("address prefix cannot be empty")
 	}
 
 	// Hash pubKeyBytes as: RIPEMD160(SHA256(public_key_bytes))
@@ -27,5 +32,5 @@ func publicKeyToCosmosBech32Address(addressPrefix string, pubKeyBytes []byte) st
 	if err != nil {
 		panic(err)
 	}
-	return address
+	return address, nil
 }

--- a/x/ssi/verification/caip10.go
+++ b/x/ssi/verification/caip10.go
@@ -1,50 +1,35 @@
 package verification
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/hypersign-protocol/hid-node/x/ssi/types"
 )
 
 // Extracts the blockchain address from blockchainAccountId
-func getBlockchainAddress(blockchainAccountId string) string {
-	blockchainAccountIdElements := strings.Split(blockchainAccountId, ":")
-	blockchainAddress := blockchainAccountIdElements[len(blockchainAccountIdElements)-1]
-	return blockchainAddress
+func getBlockchainAddress(blockchainAccountId string) (string, error) {
+	bid, err := types.NewBlockchainId(blockchainAccountId)
+	if err != nil {
+		return "", err
+	}
+
+	return bid.BlockchainAddress, nil
 }
 
-// getChainIdFromBlockchainAccountId extracts chain from blockchainAccountId
-func getChainIdFromBlockchainAccountId(blockchainAccountId string) string {
-	chainIdIdx := 1
+// getChainIdFromBlockchainAccountId extracts chain-id from blockchainAccountId
+func getChainIdFromBlockchainAccountId(blockchainAccountId string) (string, error) {
+	bid, err := types.NewBlockchainId(blockchainAccountId)
+	if err != nil {
+		return "", err
+	}
 
-	blockchainAccountIdElements := strings.Split(blockchainAccountId, ":")
-	blockchainChainId := blockchainAccountIdElements[chainIdIdx]
-	return blockchainChainId
+	return bid.ChainId, nil
 }
 
 // Extracts the CAIP-10 prefix from blockchainAccountId and returns the chain spec
 func getCAIP10Prefix(blockchainAccountId string) (string, error) {
-	segments := strings.Split(blockchainAccountId, ":")
-
-	// Validate blockchainAccountId
-	if len(segments) != 3 {
-		return "", fmt.Errorf(
-			"invalid CAIP-10 format for blockchainAccountId '%v'. Please refer: https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md",
-			blockchainAccountId,
-		)
+	bid, err := types.NewBlockchainId(blockchainAccountId)
+	if err != nil {
+		return "", err
 	}
 
-	// Prefix check
-	if segments[0] == types.EthereumCAIP10Prefix {
-		return types.EthereumCAIP10Prefix, nil
-	} else if segments[0] == types.CosmosCAIP10Prefix {
-		return types.CosmosCAIP10Prefix, nil
-	} else {
-		return "", fmt.Errorf(
-			"unsupported CAIP-10 prefix in blockchainAccountId '%v'. Supported CAIP-10 prefixes: %v",
-			blockchainAccountId,
-			types.CAIP10PrefixForEcdsaSecp256k1RecoveryMethod2020,
-		)
-	}
+	return bid.CAIP10Prefix, nil
 }


### PR DESCRIPTION
Supported Ethereum Chains:

Mainnet Chains:
```
Ethereum Mainnet - 1
Polygon Mainnet - 137
Binance Smart Chain - 56
```

Testnet Chains:
```
Ropsten (Ethereum Testnet) - 3
Rinkeby (Ethereum Testnet) - 4
Goerli (Ethereum Testnet) - 5
Polygon Mumbai Testnet - 80001
Binance Smart Chain Testnet - 97
```