### PR TITLE
feat: added CLI commands to generate a minimal DID Document

### DIFF
--- a/cmd/hid-noded/cmd/generate_ssi.go
+++ b/cmd/hid-noded/cmd/generate_ssi.go
@@ -1,0 +1,261 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/hypersign-protocol/hid-node/app"
+	"github.com/hypersign-protocol/hid-node/x/ssi/types"
+	"github.com/multiformats/go-multibase"
+	"github.com/spf13/cobra"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const fromFlag = "from"
+const didAliasFlag = "did-alias"
+const keyringBackendFlag = "keyring-backend"
+const didNamespaceFlag = "did-namespace"
+
+func generateSSICmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ssi-tools",
+		Short: "commands to experiment around Self Sovereign Identity (SSI) documents",
+	}
+
+	cmd.AddCommand(generateDidCmd())
+	cmd.AddCommand(showDidByAliasCmd())
+	cmd.AddCommand(listAllDidAliasesCmd())
+
+	return cmd
+}
+
+func listAllDidAliasesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-did-aliases",
+		Short: "List all DID Document alias names",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			didAliasConfig, err := types.GetDidAliasConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			result := []map[string]string{}
+
+			if _, err := os.Stat(didAliasConfig.DidAliasDir); err != nil {
+				if os.IsNotExist(err) {
+					fmt.Fprintf(cmd.ErrOrStderr(), "%v\n\n", []string{})
+					return nil
+				}
+			}
+			didJsonFiles, err := os.ReadDir(didAliasConfig.DidAliasDir)
+			if err != nil {
+				return err
+			}
+
+			// Consider only those files whose extensions are '.json'
+			for _, didJsonFile := range didJsonFiles {
+				isDidJsonFile := !didJsonFile.IsDir() && (strings.Split(didJsonFile.Name(), ".")[1] == "json")
+				if isDidJsonFile {
+					unit := map[string]string{}
+					didDocBytes, err := os.ReadFile(filepath.Join(didAliasConfig.DidAliasDir, didJsonFile.Name()))
+					if err != nil {
+						return err
+					}
+
+					var didDoc types.Did
+					err = clientCtx.Codec.UnmarshalJSON(didDocBytes, &didDoc)
+					if err != nil {
+						// Ignore any files which are not able to parse into type.Did
+						continue
+					}
+
+					unit["did"] = didDoc.Id
+					unit["alias"] = strings.Split(didJsonFile.Name(), ".")[0]
+					result = append(result, unit)
+				} else {
+					continue
+				}
+			}
+
+			// Indent Map
+			resultBytes, err := json.MarshalIndent(result, "", " ")
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintf(cmd.ErrOrStderr(), "%v\n", string(resultBytes))
+			return err
+		},
+	}
+	return cmd
+}
+
+func showDidByAliasCmd() *cobra.Command {
+	exampleString := "hid-noded ssi-tools show-did-by-alias didsample3"
+
+	cmd := &cobra.Command{
+		Use:     "show-did-by-alias [alias-name]",
+		Args:    cobra.ExactArgs(1),
+		Example: exampleString,
+		Short:   "Retrieve the Did Document by a alias name",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			didAliasConfig, err := types.GetDidAliasConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			aliasName := args[0]
+			aliasFile := aliasName + ".json"
+
+			if _, err := os.Stat(didAliasConfig.DidAliasDir); err != nil {
+				if os.IsNotExist(err) {
+					fmt.Fprintf(cmd.ErrOrStderr(), "DID Document alias '%v' does not exist\n", aliasName)
+					return nil
+				}
+			}
+
+			didDocBytes, err := os.ReadFile(filepath.Join(didAliasConfig.DidAliasDir, aliasFile))
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "DID Document alias '%v' does not exist\n", aliasName)
+				return nil
+			}
+
+			_, err = fmt.Fprintf(cmd.ErrOrStderr(), "%v\n", string(didDocBytes))
+			return err
+		},
+	}
+
+	return cmd
+}
+
+func generateDidCmd() *cobra.Command {
+	exampleString1 := "hid-noded ssi-tools generate-did --from hid1kspgn6f5hmurulx4645ch6rf0kt90jpv5ydykp --keyring-backend test --did-alias example1"
+	exampleString2 := "hid-noded ssi-tools generate-did --from node1 --keyring-backend test --did-alias example2"
+	exampleString3 := "hid-noded ssi-tools generate-did --from node1 --keyring-backend test --did-alias example3 --did-namespace devnet"
+
+	cmd := &cobra.Command{
+		Use:     "generate-did",
+		Short:   "Generates a DID Document",
+		Example: exampleString1 + "\n" + exampleString2 + "\n" + exampleString3,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Get the flags
+			account, err := cmd.Flags().GetString(fromFlag)
+			if err != nil {
+				return err
+			}
+			if account == "" {
+				return fmt.Errorf("no value provided for --from flag")
+			}
+
+			didAlias, err := cmd.Flags().GetString(didAliasFlag)
+			if err != nil {
+				return err
+			}
+			if didAlias == "" {
+				return fmt.Errorf("no value provided for --did-alias flag")
+			}
+
+			keyringBackend, err := cmd.Flags().GetString(keyringBackendFlag)
+			if err != nil {
+				return err
+			}
+			if keyringBackend == "" {
+				return fmt.Errorf("no value provided for --keyring-backend flag")
+			}
+
+			didNamespace, err := cmd.Flags().GetString(didNamespaceFlag)
+			if err != nil {
+				return err
+			}
+
+			// Get Public Key from keyring account
+			var kr keyring.Keyring
+			appName := "hid-noded-keyring"
+			didAliasConfig, err := types.GetDidAliasConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			switch keyringBackend {
+			case "test":
+				kr, err = keyring.New(appName, "test", didAliasConfig.HidNodeConfigDir, nil)
+				if err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("unsupported keyring-backend : %v", keyringBackend)
+			}
+
+			// Handle both key name as well as key address
+			var userKeyInfo keyring.Info
+			var errAccountFetch error
+
+			userKeyInfo, errAccountFetch = kr.Key(account)
+			if errAccountFetch != nil {
+				if accountAddr, err := sdk.AccAddressFromBech32(account); err != nil {
+					return err
+				} else {
+					userKeyInfo, errAccountFetch = kr.KeyByAddress(accountAddr)
+					if errAccountFetch != nil {
+						return errAccountFetch
+					}
+				}
+			}
+
+			pubKeyBytes := userKeyInfo.GetPubKey().Bytes()
+			pubKeyMultibase, err := multibase.Encode(multibase.Base58BTC, pubKeyBytes)
+			if err != nil {
+				return err
+			}
+			userBlockchainAddress := sdk.MustBech32ifyAddressBytes(
+				app.AccountAddressPrefix,
+				userKeyInfo.GetAddress().Bytes(),
+			)
+
+			// Generate a DID document with both publicKeyMultibase and blockchainAccountId
+			didDoc := generateDidDoc(didNamespace, pubKeyMultibase, userBlockchainAddress)
+
+			// Construct the JSON and store it in $HOME/.hid-node/generated-ssi-docs
+			if _, err := os.Stat(didAliasConfig.DidAliasDir); err != nil {
+				if os.IsNotExist(err) {
+					if err := os.Mkdir(didAliasConfig.DidAliasDir, os.ModePerm); err != nil {
+						return err
+					}
+				} else {
+					return err
+				}
+			}
+
+			didJsonBytes, err := json.MarshalIndent(didDoc, "", " ")
+			if err != nil {
+				return err
+			}
+			didJsonFilename := didAlias + ".json"
+			didJsonPath := filepath.Join(didAliasConfig.DidAliasDir, didJsonFilename)
+			if err := os.WriteFile(didJsonPath, didJsonBytes, 0644); err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintf(cmd.ErrOrStderr(), "DID Document alias '%v' (didId: %v) has been successfully generated at %v\n", didAlias, didDoc.Id, didJsonPath)
+
+			return err
+		},
+	}
+
+	cmd.Flags().String(fromFlag, "", "name of account while will sign the DID Document")
+	cmd.Flags().String(didAliasFlag, "", "alias of the generated DID Document which can be referred to while registering on-chain")
+	cmd.Flags().String(keyringBackendFlag, "", "supported keyring backend: (test)")
+	cmd.Flags().String(didNamespaceFlag, "", "namespace of DID Document Id")
+	return cmd
+}

--- a/cmd/hid-noded/cmd/generate_ssi_utils.go
+++ b/cmd/hid-noded/cmd/generate_ssi_utils.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"github.com/hypersign-protocol/hid-node/x/ssi/types"
+)
+
+func formDidId(didNamespace string, publicKeyMultibase string) string {
+	if didNamespace != "" {
+		return types.DocumentIdentifierDid + ":" + types.DidMethod + ":" + didNamespace + ":" + publicKeyMultibase
+	} else {
+		return types.DocumentIdentifierDid + ":" + types.DidMethod + ":" + publicKeyMultibase
+	}
+}
+
+func generateDidDoc(didNamespace string, publicKeyMultibase string, userAddress string) *types.Did {
+	didId := formDidId(didNamespace, publicKeyMultibase)
+
+	return &types.Did{
+		Id:         didId,
+		Controller: []string{didId},
+		VerificationMethod: []*types.VerificationMethod{
+			{
+				Id:                  didId + "#k1",
+				Type:                types.EcdsaSecp256k1VerificationKey2019,
+				Controller:          didId,
+				PublicKeyMultibase:  publicKeyMultibase,
+				BlockchainAccountId: types.CosmosCAIP10Prefix + ":jagrat:" + userAddress,
+			},
+		},
+	}
+}

--- a/cmd/hid-noded/cmd/root.go
+++ b/cmd/hid-noded/cmd/root.go
@@ -114,6 +114,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 	)
 
 	rootCmd.AddCommand(server.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Codec))
+	rootCmd.AddCommand(generateSSICmd())
 }
 
 func addModuleInitFlags(startCmd *cobra.Command) {

--- a/localnetsetup.sh
+++ b/localnetsetup.sh
@@ -38,7 +38,7 @@ cat $HOME/.hid-node/config/genesis.json | jq '.app_state["gov"]["deposit_params"
 cat $HOME/.hid-node/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="50s"' > $HOME/.hid-node/config/tmp_genesis.json && mv $HOME/.hid-node/config/tmp_genesis.json $HOME/.hid-node/config/genesis.json
 
 # update ssi genesis
-cat $HOME/.hid-node/config/genesis.json | jq '.app_state["ssi"]["chain_namespace"]="testnet"' > $HOME/.hid-node/config/tmp_genesis.json && mv $HOME/.hid-node/config/tmp_genesis.json $HOME/.hid-node/config/genesis.json
+cat $HOME/.hid-node/config/genesis.json | jq '.app_state["ssi"]["chain_namespace"]="devnet"' > $HOME/.hid-node/config/tmp_genesis.json && mv $HOME/.hid-node/config/tmp_genesis.json $HOME/.hid-node/config/genesis.json
 
 # update mint genesis
 cat $HOME/.hid-node/config/genesis.json | jq '.app_state["mint"]["params"]["mint_denom"]="uhid"' > $HOME/.hid-node/config/tmp_genesis.json && mv $HOME/.hid-node/config/tmp_genesis.json $HOME/.hid-node/config/genesis.json
@@ -59,6 +59,12 @@ sed -i -E 's|allow_duplicate_ip = false|allow_duplicate_ip = true|g' $HOME/.hid-
 sed -i -E 's|addr_book_strict = true|addr_book_strict = false|g' $HOME/.hid-node/config/config.toml
 sed -i -E 's|cors_allowed_origins = \[\]|cors_allowed_origins = \[\"\*\"\]|g' $HOME/.hid-node/config/config.toml
 
-echo -e "\nConfiguarations set, you are ready to run hid-noded now!"
+echo -e "\nConfiguration set up is done, you are ready to run hid-noded now!"
+
+echo -e "\nPlease note the important chain configurations below:"
+
+echo -e "\nRPC server address: http://localhost:26657"
+echo -e "API server address: http://localhost:1317"
+echo -e "DID Namespace: devnet"
 
 echo -e "\nEnter the command 'hid-noded start' to start a single node blockchain."

--- a/x/ssi/types/did_alias.go
+++ b/x/ssi/types/did_alias.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"path/filepath"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/spf13/cobra"
+)
+
+type DidAliasConfig struct {
+	HidNodeConfigDir string
+	DidAliasDir      string
+}
+
+func GetDidAliasConfig(cmd *cobra.Command) (*DidAliasConfig, error) {
+	configDir, err := cmd.Flags().GetString(flags.FlagHome)
+	if err != nil {
+		return nil, err
+	}
+
+	didAliasDir := filepath.Join(configDir, "generated-ssi-docs")
+
+	return &DidAliasConfig{
+		HidNodeConfigDir: configDir,
+		DidAliasDir:      didAliasDir,
+	}, nil
+}


### PR DESCRIPTION
The PR aims to introduce CLI commands to generate a minimal DID document, and extend the current `create-did` capability to refer to the generated DID Document, without the need of explicitly specifying the DID Document JSON.

1. Generation of a DID Document using an alias:

```
hid-noded ssi-tools generate-did --from <name or address of account> --keyring-backend <test is the only supported keyring backend> --did-alias <name of the DID Document alias> --did-namespace <Optional Flag to specify the DID Namespace>

Example:
hid-noded ssi-tools generate-did --from node1 --keyring-backend test --did-alias production1
hid-noded ssi-tools generate-did --from node1 --keyring-backend test --did-alias production1 --did-namespace devnet
```

2. List all the DID aliases generated:

```
hid-noded ssi-tools list-did-aliases
```

3. Show the DID Document of a particular DID alias

```
hid-noded ssi-tools show-did-by-alias [alias-name]

Example:
hid-noded ssi-tools show-did-by-alias production1
```

4. Register the DID Alias on-chain

```
hid-noded tx ssi create-did --did-alias <name of the DID Document alias>

Example:
hid-noded tx ssi create-did --did-alias production1 --from node1 --keyring-backend test --broadcast-mode block --chain-id hidnode
```
**Note**: If the author of the `CreateDID` Transaction is not the author of the referred DID Alias, the transaction will fail.