### PR TITLE
feat: added events for successful registration of did-document, schema and credential status

### DIFF
--- a/x/ssi/keeper/msg_server_create_did.go
+++ b/x/ssi/keeper/msg_server_create_did.go
@@ -102,6 +102,11 @@ func (k msgServer) CreateDID(goCtx context.Context, msg *types.MsgCreateDID) (*t
 		}
 	}
 
+	// Emit a successful DID Document Registration event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent("create_did", sdk.NewAttribute("tx_author", msg.GetCreator())),
+	)
+
 	return &types.MsgCreateDIDResponse{Id: id}, nil
 }
 

--- a/x/ssi/keeper/msg_server_credential.go
+++ b/x/ssi/keeper/msg_server_credential.go
@@ -104,6 +104,11 @@ func (k msgServer) RegisterCredentialStatus(goCtx context.Context, msg *types.Ms
 
 		id = k.RegisterCredentialStatusInState(ctx, cred)
 
+		// Emit a successful Credential Status Registration event
+		ctx.EventManager().EmitEvent(
+			sdk.NewEvent("create_credential_status", sdk.NewAttribute("tx_author", msg.GetCreator())),
+		)
+
 	} else {
 		cred, err := k.updateCredentialStatus(ctx, msg)
 		if err != nil {

--- a/x/ssi/keeper/msg_server_schema.go
+++ b/x/ssi/keeper/msg_server_schema.go
@@ -81,5 +81,10 @@ func (k msgServer) CreateSchema(goCtx context.Context, msg *types.MsgCreateSchem
 
 	id := k.RegisterSchemaInStore(ctx, schema)
 
+	// Emit a successful Schema Registration event
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent("create_schema", sdk.NewAttribute("tx_author", msg.GetCreator())),
+	)
+
 	return &types.MsgCreateSchemaResponse{Id: id}, nil
 }


### PR DESCRIPTION
This PR intends to introduce `events` upon successful registration of DID Document, Schema and Credential Status. The following are the description of events

| Event Name | Key | Value |
| ---------------- | ------ | ------- |
| create_did | tx_author | <Transaction author's address > |
| create_schema | tx_author | <Transaction author's address > |
| create_credential_status | tx_author | <Transaction author's address > | 

After connecting to the WebSocket server of `hid-node`, subscribing to these events can done as follows:

```
{"jsonrpc": "2.0","method": "subscribe","id": 0,"params": {"query": "create_did.tx_author='hid1arpjwnd5ujt5lrgvah49nyy63qmunfeh085y4v'"}}
```

```
{"jsonrpc": "2.0","method": "subscribe","id": 0,"params": {"query": "create_schema.tx_author='hid1arpjwnd5ujt5lrgvah49nyy63qmunfeh085y4v'"}}
```

```
{"jsonrpc": "2.0","method": "subscribe","id": 0,"params": {"query": "create_credential_status.tx_author='hid1arpjwnd5ujt5lrgvah49nyy63qmunfeh085y4v'"}}
```

The transactions can also fetched using the following API endpoint:

```
<API_HOST>/cosmos/tx/v1beta1/txs?events="create_did.tx_author='hid1jx7uayq98zgwzrqchfpcpfr4508za04krwxp3a'"
```
The above endpoint fetches those transactions where the event `create_did` has the attribute `tx_author` value to be `hid1jx7uayq98zgwzrqchfpcpfr4508za04krwxp3a`
