### PR TITLE
Support for `X25519KeyAgreementKey2020` and `X25519KeyAgreementKeyEIP5630` based keys

### DIFF
--- a/tests/e2e/ssi_tests/e2e_tests.py
+++ b/tests/e2e/ssi_tests/e2e_tests.py
@@ -56,7 +56,7 @@ def key_agrement_test():
     create_tx_cmd = form_did_create_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
     run_blockchain_command(create_tx_cmd, f"Registering Alice's DID with Id: {did_doc_string['id']}")
 
-    print("\n--4. FAIL: An attempt is made to update the DID Document by passing the signature of X25519KeyVerificationKey2020 based verification method")
+    print("\n--4. FAIL: An attempt is made to update the DID Document by passing the signature of X25519KeyAgreementKey2020 based verification method")
     signers = []
     did_doc_string["context"] = ["some_context"]
     did_doc_string["authentication"] = []
@@ -67,7 +67,7 @@ def key_agrement_test():
     }
     signers.append(signPair_x25519)
     update_tx_cmd = form_did_update_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
-    run_blockchain_command(update_tx_cmd, f"DID Document update using X25519KeyVerificationKey2020 based verification method", True)
+    run_blockchain_command(update_tx_cmd, f"DID Document update using X25519KeyAgreementKey2020 based verification method", True)
 
     print("\n--5. PASS: An attempt is made to update the DID Document by passing the signature of Ed25519VerificationKey2020 based verification method")
     signers = []
@@ -77,11 +77,11 @@ def key_agrement_test():
     update_tx_cmd = form_did_update_tx_multisig(did_doc_string, signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
     run_blockchain_command(update_tx_cmd, f"DID Document {did_doc_string['id']} update using Ed25519VerificationKey2020 based verification method")
 
-    print("\n--6. FAIL: An attempt is made to deactivate the DID Document by passing the signature of X25519KeyVerificationKey2020 based verification method--\n")
+    print("\n--6. FAIL: An attempt is made to deactivate the DID Document by passing the signature of X25519KeyAgreementKey2020 based verification method--\n")
     signers = []
     signers.append(signPair_x25519)
     deactivate_tx_cmd = form_did_deactivate_tx_multisig(did_doc_string["id"], signers, DEFAULT_BLOCKCHAIN_ACCOUNT_NAME)
-    run_blockchain_command(deactivate_tx_cmd, f"DID Document deactivate using X25519KeyVerificationKey2020 based verification method", True)
+    run_blockchain_command(deactivate_tx_cmd, f"DID Document deactivate using X25519KeyAgreementKey2020 based verification method", True)
 
     print("\n--7. PASS: An attempt is made to deactivate the DID Document by passing the signature of Ed25519VerificationKey2020 based verification method--\n")
     signers = []

--- a/tests/e2e/ssi_tests/run.py
+++ b/tests/e2e/ssi_tests/run.py
@@ -34,6 +34,7 @@ def run_all_tests():
     vm_type_test()
     method_specific_id_test()
     unique_wallet_address_test()
+    key_agrement_test()
     
     print("============= 😃️ All test cases completed successfully ============== \n")
 

--- a/tests/e2e/ssi_tests/utils.py
+++ b/tests/e2e/ssi_tests/utils.py
@@ -59,6 +59,19 @@ def generate_key_pair(algo="ed25519"):
     kp = json.loads(result_str)
     return kp
 
+def add_keyAgreeemnt_pubKeyMultibase(verification_method, type):
+    if verification_method["type"] != "Ed25519VerificationKey2020":
+        raise Exception("verification method " + verification_method["id"] + " must be of type Ed25519VerificationKey2020")
+    
+    if type == "X25519KeyAgreementKey2020":
+        verification_method["type"] = "X25519KeyAgreementKey2020"
+    elif type == "X25519KeyAgreementKeyEIP5630":
+        verification_method["type"] = "X25519KeyAgreementKeyEIP5630"
+    else:
+        raise Exception("invalid key agreement type " + type)
+
+    return verification_method
+
 def generate_document_id(doc_type: str, kp: dict = None, algo: str = "ed25519", is_uuid: bool =False):
     id = ""
     if not kp:

--- a/x/ssi/keeper/msg_server_create_did.go
+++ b/x/ssi/keeper/msg_server_create_did.go
@@ -165,6 +165,13 @@ func getVerificationMethodsForCreateDID(didDocument *types.Did) ([]*types.Verifi
 		if vm.Controller == didDocument.Id {
 			foundAtleastOneSubjectVM = true
 		}
+
+		// Skip X25519KeyAgreementKey2020 or X25519KeyAgreementKey2020 because these
+		// are not allowed for Authentication and Assertion purposes
+		if (vm.Type == types.X25519KeyAgreementKey2020) || (vm.Type == types.X25519KeyAgreementKeyEIP5630) {
+			continue
+		}
+
 		mustHaveVerificaitonMethods = append(mustHaveVerificaitonMethods, vm)
 	}
 

--- a/x/ssi/keeper/msg_server_update_did.go
+++ b/x/ssi/keeper/msg_server_update_did.go
@@ -270,6 +270,11 @@ func getVerificationMethodsForUpdateDID(existingVMs []*types.VerificationMethod,
 	// Make map of existing VMs
 	existingVmMap := map[string]*types.VerificationMethod{}
 	for _, vm := range existingVMs {
+		// Skip X25519KeyAgreementKey2020 or X25519KeyAgreementKey2020 because these
+		// are not allowed for Authentication and Assertion purposes
+		if ((vm.Type == types.X25519KeyAgreementKey2020) || (vm.Type == types.X25519KeyAgreementKeyEIP5630)) {
+			continue
+		}
 		existingVmMap[vm.Id] = vm
 	}
 
@@ -280,7 +285,7 @@ func getVerificationMethodsForUpdateDID(existingVMs []*types.VerificationMethod,
 		// Check if VM is present in existing VM map.
 		// If it's not present, the VM is being added to existing Did Document.
 		// Add the VM to "required" group
-		if _, present := existingVmMap[vm.Id]; !present {
+		if _, present := existingVmMap[vm.Id]; !present && ((vm.Type != types.X25519KeyAgreementKey2020) && (vm.Type != types.X25519KeyAgreementKeyEIP5630))  {
 			updatedVms = append(
 				updatedVms,
 				vm,

--- a/x/ssi/types/common.go
+++ b/x/ssi/types/common.go
@@ -8,12 +8,16 @@ const MSINonBlockchainAccountId = "MSINonBlockchainAccountId"
 const Ed25519VerificationKey2020 = "Ed25519VerificationKey2020"
 const EcdsaSecp256k1VerificationKey2019 = "EcdsaSecp256k1VerificationKey2019"
 const EcdsaSecp256k1RecoveryMethod2020 = "EcdsaSecp256k1RecoveryMethod2020"
+const X25519KeyAgreementKey2020 = "X25519KeyAgreementKey2020"
+const X25519KeyAgreementKeyEIP5630 = "X25519KeyAgreementKeyEIP5630" // TODO: Temporary spec name for KeyAgreement type from Metamask
 
 // Mapping between Verification Key and its corresponding Signature
 var VerificationKeySignatureMap = map[string]string{
 	Ed25519VerificationKey2020:        "Ed25519Signature2020",
 	EcdsaSecp256k1VerificationKey2019: "EcdsaSecp256k1Signature2019",
 	EcdsaSecp256k1RecoveryMethod2020:  "EcdsaSecp256k1RecoverySignature2020",
+	X25519KeyAgreementKey2020: "", // Authentication and Assertion are not allowed
+	X25519KeyAgreementKeyEIP5630: "", // Authentication and Assertion are not allowed
 }
 
 var supportedVerificationMethodTypes []string = func() []string {

--- a/x/ssi/verification/crypto.go
+++ b/x/ssi/verification/crypto.go
@@ -53,6 +53,10 @@ func verify(extendedVm *types.ExtendedVerificationMethod, ssiMsg types.SsiMsg) e
 		return verifyEcdsaSecp256k1VerificationKey2019Key(extendedVm, docBytes)
 	case types.EcdsaSecp256k1RecoveryMethod2020:
 		return verifyEcdsaSecp256k1RecoveryMethod2020Key(extendedVm, docBytes)
+	case types.X25519KeyAgreementKey2020:
+		return verifyX25519KeyAgreementKey2020Key(extendedVm)
+	case types.X25519KeyAgreementKeyEIP5630:
+		return verifyX25519KeyAgreementKeyEIP5630Key(extendedVm)
 	default:
 		return fmt.Errorf("unsupported verification method: %s", extendedVm.Type)
 	}
@@ -240,4 +244,30 @@ func verifyEthereumBlockchainAccountId(extendedVm *types.ExtendedVerificationMet
 	} else {
 		return nil
 	}
+}
+
+// verifyX25519KeyAgreementKey2020Key verifies the verification key for verification method type X25519KeyAgreementKey2020
+func verifyX25519KeyAgreementKey2020Key(extendedVm *types.ExtendedVerificationMethod) error {
+	_, _, err := multibase.Decode(extendedVm.PublicKeyMultibase)
+	if err != nil {
+		return fmt.Errorf(
+			"cannot decode X25519KeyAgreementKey2020 public key %s",
+			extendedVm.PublicKeyMultibase,
+		)
+	}
+
+	return nil
+}
+
+// verifyX25519KeyAgreementKeyEIP5630Key verifies the verification key for verification method type X25519KeyAgreementKeyEIP5630
+func verifyX25519KeyAgreementKeyEIP5630Key(extendedVm *types.ExtendedVerificationMethod) error {
+	_, _, err := multibase.Decode(extendedVm.PublicKeyMultibase)
+	if err != nil {
+		return fmt.Errorf(
+			"cannot decode X25519KeyAgreementKeyEIP5630 public key %s",
+			extendedVm.PublicKeyMultibase,
+		)
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR aims to introduce support for `X25519KeyAgreementKey2020` and `X25519KeyAgreementKeyEIP5630` verification method types

These keys are based on `keyAgreement` attribute. Hence, any verification method of these types can only be part of the `keyAgreement` attribute only, and hence they are not allowed to be used for Authentication as well as Assertion purposes. This also means that `Ed25519VerificationKey2020` based Verification Methods cannot be used for `keyAgreement` Purposes

Test Cases:

1. FAIL: Ed25519VerificationKey2020 based Verification Method ID being added to keyAgreement attribute

2. FAIL: X25519KeyAgreementKey2020 based Verification Method ID being added to authentication attribute

3. PASS: A DID Document is created with Ed25519VerificationKey2020 and X25519KeyAgreementKey2020 based VMs

4. FAIL: An attempt is made to update the DID Document by passing the signature of X25519KeyAgreementKey2020 based verification method

5. PASS: An attempt is made to update the DID Document by passing the signature of Ed25519VerificationKey2020 based verification method

6. FAIL: An attempt is made to deactivate the DID Document by passing the signature of X25519KeyAgreementKey2020 based verification method

7. PASS: An attempt is made to deactivate the DID Document by passing the signature of Ed25519VerificationKey2020 based verification method

