### PR TITLE
Typos fix

### DIFF
--- a/cmd/hid-noded/cmd/debug_extensions.go
+++ b/cmd/hid-noded/cmd/debug_extensions.go
@@ -34,7 +34,7 @@ func extendDebug(debugCmd *cobra.Command) *cobra.Command {
 func bjjCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bjj",
-		Short: "BabyJubJub commonds",
+		Short: "BabyJubJub commands, commons, commends",
 	}
 
 	cmd.AddCommand(bjjRandomCmd())

--- a/cmd/hid-noded/cmd/debug_extensions_utils.go
+++ b/cmd/hid-noded/cmd/debug_extensions_utils.go
@@ -94,7 +94,7 @@ func getDocumentSignature(doc types.SsiMsg, docProof *types.DocumentProof, priva
 			return "", err
 		}
 	default:
-		panic("recieved unsupported signing-algo. Supported algorithms are: [Ed25519Signature2020, EcdsaSecp256k1Signature2019, EcdsaSecp256k1RecoverySignature2020, BbsBlsSignature2020, BJJSignature2021]")
+		panic("received unsupported signing-algo. Supported algorithms are: [Ed25519Signature2020, EcdsaSecp256k1Signature2019, EcdsaSecp256k1RecoverySignature2020, BbsBlsSignature2020, BJJSignature2021]")
 	}
 
 	return signature, nil

--- a/x/ssi/ld-context/types.go
+++ b/x/ssi/ld-context/types.go
@@ -13,8 +13,8 @@ type JsonLdDocument interface {
 }
 
 // It is a similar to `Did` struct, with the exception that the `context` attribute is of type
-// `contextObject` instead of `[]string`, which is meant for accomodating Context JSON body
-// having arbritrary attributes. It should be used for performing Canonization.
+// `contextObject` instead of `[]string`, which is meant for accommodating Context JSON body
+// having arbitrary attributes. It should be used for performing Canonization.
 type JsonLdDidDocument struct {
 	Context              []contextObject             `json:"@context,omitempty"`
 	Id                   string                      `json:"id,omitempty"`
@@ -36,7 +36,7 @@ func (doc *JsonLdDidDocument) GetContext() []contextObject {
 // NewJsonLdDidDocument returns a new JsonLdDid struct from input Did
 func NewJsonLdDidDocument(didDoc *types.DidDocument) *JsonLdDidDocument {
 	if len(didDoc.Context) == 0 {
-		panic("atleast one context url must be provided for DID Document for Canonization")
+		panic("at least one context url must be provided for DID Document for Canonization")
 	}
 
 	var jsonLdDoc *JsonLdDidDocument = &JsonLdDidDocument{}
@@ -64,8 +64,8 @@ func NewJsonLdDidDocument(didDoc *types.DidDocument) *JsonLdDidDocument {
 }
 
 // It is a similar to `CredentialStatusDocument` struct, with the exception that the `context` attribute is of type
-// `contextObject` instead of `[]string`, which is meant for accomodating Context JSON body
-// having arbritrary attributes. It should be used for performing Canonization.
+// `contextObject` instead of `[]string`, which is meant for accommodating Context JSON body
+// having arbitrary attributes. It should be used for performing Canonization.
 type JsonLdCredentialStatus struct {
 	Context                  []contextObject `json:"@context,omitempty"`
 	Id                       string          `json:"id,omitempty"`
@@ -100,7 +100,7 @@ func (doc *JsonLdCredentialStatusBJJ) GetContext() []contextObject {
 // NewJsonLdCredentialStatus returns a new JsonLdCredentialStatus struct from input Credential Status
 func NewJsonLdCredentialStatus(credStatusDoc *types.CredentialStatusDocument) *JsonLdCredentialStatus {
 	if len(credStatusDoc.Context) == 0 {
-		panic("atleast one context url must be provided in the Credential Status Document for Canonization")
+		panic("at least one context url must be provided in the Credential Status Document for Canonization")
 	}
 
 	var jsonLdCredentialStatus *JsonLdCredentialStatus = &JsonLdCredentialStatus{}
@@ -126,7 +126,7 @@ func NewJsonLdCredentialStatus(credStatusDoc *types.CredentialStatusDocument) *J
 
 func NewJsonLdCredentialStatusBJJ(credStatusDoc *types.CredentialStatusDocument, docProof *types.DocumentProof) *JsonLdCredentialStatusBJJ {
 	if len(credStatusDoc.Context) == 0 {
-		panic("atleast one context url must be provided in the Credential Status Document for Canonization")
+		panic("at least one context url must be provided in the Credential Status Document for Canonization")
 	}
 
 	var jsonLdCredentialStatus *JsonLdCredentialStatusBJJ = &JsonLdCredentialStatusBJJ{}
@@ -171,7 +171,7 @@ func (doc *JsonLdDocumentProof) GetContext() []contextObject {
 
 func NewJsonLdDocumentProof(didDocProof *types.DocumentProof, didContexts []string) *JsonLdDocumentProof {
 	if len(didContexts) == 0 {
-		panic("atleast one context url must be provided for DID Document for Canonization")
+		panic("at least one context url must be provided for DID Document for Canonization")
 	}
 
 	var jsonLdDoc *JsonLdDocumentProof = &JsonLdDocumentProof{}
@@ -193,8 +193,8 @@ func NewJsonLdDocumentProof(didDocProof *types.DocumentProof, didContexts []stri
 }
 
 // It is a similar to `CredentialSchemaDocument` struct, with the exception that the `context` attribute is of type
-// `contextObject` instead of `[]string`, which is meant for accomodating Context JSON body
-// having arbritrary attributes. It should be used for performing Canonization.
+// `contextObject` instead of `[]string`, which is meant for accommodating Context JSON body
+// having arbitrary attributes. It should be used for performing Canonization.
 type JsonLdCredentialSchema struct {
 	Context      []contextObject                 `json:"@context,omitempty"`
 	Type         string                          `json:"type,omitempty"`
@@ -228,7 +228,7 @@ func (doc *JsonLdCredentialSchemaBJJ) GetContext() []contextObject {
 
 func NewJsonLdCredentialSchema(credSchema *types.CredentialSchemaDocument) *JsonLdCredentialSchema {
 	if len(credSchema.Context) == 0 {
-		panic("atleast one context url must be provided for DID Document for Canonization")
+		panic("at least one context url must be provided for DID Document for Canonization")
 	}
 
 	var jsonLdDoc *JsonLdCredentialSchema = &JsonLdCredentialSchema{}
@@ -254,7 +254,7 @@ func NewJsonLdCredentialSchema(credSchema *types.CredentialSchemaDocument) *Json
 
 func NewJsonLdCredentialSchemaBJJ(credSchema *types.CredentialSchemaDocument, docProof *types.DocumentProof) *JsonLdCredentialSchemaBJJ {
 	if len(credSchema.Context) == 0 {
-		panic("atleast one context url must be provided for DID Document for Canonization")
+		panic("at least one context url must be provided for DID Document for Canonization")
 	}
 
 	var jsonLdDoc *JsonLdCredentialSchemaBJJ = &JsonLdCredentialSchemaBJJ{}
@@ -284,8 +284,8 @@ func NewJsonLdCredentialSchemaBJJ(credSchema *types.CredentialSchemaDocument, do
 }
 
 // It is a similar to `Did` struct, with the exception that the `context` attribute is of type
-// `contextObject` instead of `[]string`, which is meant for accomodating Context JSON body
-// having arbritrary attributes. It should be used for performing Canonization.
+// `contextObject` instead of `[]string`, which is meant for accommodating Context JSON body
+// having arbitrary attributes. It should be used for performing Canonization.
 type JsonLdDidDocumentWithoutVM struct {
 	Context    []contextObject `json:"@context,omitempty"`
 	Id         string          `json:"id,omitempty"`
@@ -307,7 +307,7 @@ func (doc *JsonLdDidDocumentWithoutVM) GetContext() []contextObject {
 // NewJsonLdDidDocument returns a new JsonLdDid struct from input Did
 func NewJsonLdDidDocumentWithoutVM(didDoc *types.DidDocument, docProof *types.DocumentProof) *JsonLdDidDocumentWithoutVM {
 	if len(didDoc.Context) == 0 {
-		panic("atleast one context url must be provided for DID Document for Canonization")
+		panic("at least one context url must be provided for DID Document for Canonization")
 	}
 
 	var jsonLdDoc *JsonLdDidDocumentWithoutVM = &JsonLdDidDocumentWithoutVM{}

--- a/x/ssi/types/diddoc_validation.go
+++ b/x/ssi/types/diddoc_validation.go
@@ -46,7 +46,7 @@ func isValidDidDocId(id string) error {
 		}
 	case MSINonBlockchainAccountId:
 		// Non Blockchain Account ID should be a string that supports alphanumeric characters,
-		// and dot (.) and hypen (-). The first character MUST NOT be dot (.) or hyphen (-).
+		// and dot (.) and hyphen (-). The first character MUST NOT be dot (.) or hyphen (-).
 		isValidMSI, err := regexp.MatchString(
 			"^[a-zA-Z0-9][a-zA-Z0-9.-]*$",
 			inputMSI,

--- a/x/ssi/types/genesis.go
+++ b/x/ssi/types/genesis.go
@@ -25,11 +25,11 @@ func (gs GenesisState) Validate() error {
 	maxChainNamespaceLength := 10
 
 	if len(namespace) > maxChainNamespaceLength {
-		return fmt.Errorf("chain namespace shouldn't shouldn't be more than 10, namespace recieved %s", namespace)
+		return fmt.Errorf("chain namespace shouldn't shouldn't be more than 10, namespace received %s", namespace)
 	}
 
 	if !regexPattern.MatchString(namespace) && len(namespace) != 0 {
-		return fmt.Errorf("chain namespace should be in alphanumeric format, namespace recieved %s", namespace)
+		return fmt.Errorf("chain namespace should be in alphanumeric format, namespace received %s", namespace)
 	}
 
 	return nil

--- a/x/ssi/types/query.pb.go
+++ b/x/ssi/types/query.pb.go
@@ -822,7 +822,7 @@ type QueryClient interface {
 	DidDocuments(ctx context.Context, in *QueryDidDocumentsRequest, opts ...grpc.CallOption) (*QueryDidDocumentsResponse, error)
 	// Get the Credential Status for a given credential id
 	CredentialStatusByID(ctx context.Context, in *QueryCredentialStatusRequest, opts ...grpc.CallOption) (*QueryCredentialStatusResponse, error)
-	// Get all the registed Credential Statuses
+	// Get all the registered Credential Statuses
 	CredentialStatuses(ctx context.Context, in *QueryCredentialStatusesRequest, opts ...grpc.CallOption) (*QueryCredentialStatusesResponse, error)
 	// Get the list of fixed fees for every x/ssi module transactions
 	QuerySSIFee(ctx context.Context, in *QuerySSIFeeRequest, opts ...grpc.CallOption) (*QuerySSIFeeResponse, error)
@@ -911,7 +911,7 @@ type QueryServer interface {
 	DidDocuments(context.Context, *QueryDidDocumentsRequest) (*QueryDidDocumentsResponse, error)
 	// Get the Credential Status for a given credential id
 	CredentialStatusByID(context.Context, *QueryCredentialStatusRequest) (*QueryCredentialStatusResponse, error)
-	// Get all the registed Credential Statuses
+	// Get all the registered Credential Statuses
 	CredentialStatuses(context.Context, *QueryCredentialStatusesRequest) (*QueryCredentialStatusesResponse, error)
 	// Get the list of fixed fees for every x/ssi module transactions
 	QuerySSIFee(context.Context, *QuerySSIFeeRequest) (*QuerySSIFeeResponse, error)


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /cmd/hid-noded/cmd/debug_extensions.go (Line 37)

"commonds" → "commands, commons, commends"

Corrected typo in /cmd/hid-noded/cmd/debug_extensions_utils.go (Line 97)

"recieved" → "received"

Corrected typo in /x/ssi/types/diddoc_validation.go (Line 49)

"hypen" → "hyphen"

Corrected typo in /x/ssi/types/query.pb.go (Line 825)

"registed" → "registered"

Corrected typo in /x/ssi/types/query.pb.go (Line 914)

"registed" → "registered"

Corrected typo in /x/ssi/types/genesis.go (Line 28)

"recieved" → "received"

Corrected typo in /x/ssi/types/genesis.go (Line 32)

"recieved" → "received"

Corrected typo in /x/ssi/ld-context/types.go (Line 16)

"accomodating" → "accommodating"

Corrected typo in /x/ssi/ld-context/types.go (Line 17)

"arbritrary" → "arbitrary"

Corrected typo in /x/ssi/ld-context/types.go (Line 39)

"atleast" → "at least"

**Purpose**

Improved code accuracy and professionalism by fixing typos.